### PR TITLE
Allow login without invitation, redirect based on events/admin status

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3030,22 +3030,6 @@
         "node": ">=18.12.0"
       }
     },
-    "node_modules/@nuxt/test-utils/node_modules/crossws": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/crossws/-/crossws-0.4.4.tgz",
-      "integrity": "sha512-w6c4OdpRNnudVmcgr7brb/+/HmYjMQvYToO/oTrprTwxRUiom3LYWU1PMWuD006okbUWpII1Ea9/+kwpUfmyRg==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "peerDependencies": {
-        "srvx": ">=0.7.1"
-      },
-      "peerDependenciesMeta": {
-        "srvx": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@nuxt/test-utils/node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -7401,17 +7385,6 @@
       "resolved": "https://registry.npmjs.org/colord/-/colord-2.9.3.tgz",
       "integrity": "sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==",
       "license": "MIT"
-    },
-    "node_modules/commander": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
-      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
     },
     "node_modules/comment-parser": {
       "version": "1.4.5",

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -12,10 +12,20 @@ const errorMessages: Record<string, string> = {
   'invalid-invitation': 'Your invitation link was invalid or expired. Please request a new invitation.',
 }
 
-// Redirect authenticated users to dashboard
-watchEffect(() => {
+// Redirect authenticated users to dashboard only if they have events or are admin
+watchEffect(async () => {
   if (loggedIn.value) {
-    navigateTo('/dashboard')
+    try {
+      const [meData, adminData] = await Promise.all([
+        $fetch<{ events: unknown[] }>('/api/me'),
+        $fetch<{ isAdmin: boolean }>('/api/admin/check'),
+      ])
+      if (meData.events.length > 0 || adminData.isAdmin) {
+        navigateTo('/dashboard')
+      }
+    } catch {
+      // If API calls fail, stay on the index page
+    }
   }
 })
 </script>
@@ -35,8 +45,18 @@ watchEffect(() => {
       {{ errorMessages[errorParam] }}
     </v-alert>
 
-    <p class="text-body-1 text-grey mb-6">
-      Access is by invitation only. Check your email for an invitation link.
-    </p>
+    <template v-if="loggedIn">
+      <p class="text-body-1 text-grey mb-6">
+        You are not currently associated with any event. Please contact the event organizer.
+      </p>
+    </template>
+    <template v-else>
+      <p class="text-body-1 text-grey mb-6">
+        Log in with your GitHub account or use an invitation link from the event organizer.
+      </p>
+      <v-btn color="primary" size="large" href="/auth/github" prepend-icon="mdi-github">
+        Login with GitHub
+      </v-btn>
+    </template>
   </div>
 </template>

--- a/server/routes/auth/github.get.ts
+++ b/server/routes/auth/github.get.ts
@@ -78,13 +78,19 @@ export default defineOAuthGitHubEventHandler({
     }
 
     // Returning user re-login (no invitation token)
-    const [existingUser] = await db.select()
-      .from(users)
-      .where(eq(users.githubId, user.id))
+    const existingUser = await db.query.users.findFirst({
+      where: eq(users.githubId, user.id),
+      with: {
+        userEvents: true,
+      },
+    })
 
     if (!existingUser) {
       return sendRedirect(event, '/?error=no-invitation')
     }
+
+    const hasEvents = existingUser.userEvents.length > 0
+    const userIsAdmin = isAdmin(existingUser.login)
 
     await setUserSession(event, {
       user: {
@@ -101,7 +107,11 @@ export default defineOAuthGitHubEventHandler({
       },
     })
 
-    return sendRedirect(event, '/dashboard')
+    if (hasEvents || userIsAdmin) {
+      return sendRedirect(event, '/dashboard')
+    }
+
+    return sendRedirect(event, '/')
   },
   onError(event, error) {
     console.error('GitHub OAuth error:', error)

--- a/test/nuxt/pages.test.ts
+++ b/test/nuxt/pages.test.ts
@@ -9,9 +9,9 @@ describe('Landing page (pages/index.vue)', () => {
     expect(wrapper.text()).toContain('Welcome to Unconference')
   })
 
-  it('displays the "invitation only" message', async () => {
+  it('displays the login prompt for unauthenticated users', async () => {
     const wrapper = await mountSuspended(IndexPage)
-    expect(wrapper.text()).toContain('invitation only')
+    expect(wrapper.text()).toContain('Log in with your GitHub account')
   })
 
   it('shows error alert when route has ?error=no-invitation', async () => {


### PR DESCRIPTION
## Why

Users previously could only access the app through invitation email links. This change allows users to log in directly via GitHub OAuth. After login, the app redirects them based on whether they have active event associations or admin privileges — users with neither are sent back to the index page instead of the dashboard.

## Approach

**OAuth handler** (`server/routes/auth/github.get.ts`):
- The returning-user path now eagerly loads `userEvents` alongside the user lookup
- After setting the session, checks `hasEvents || isAdmin` to decide the redirect destination
- Unknown users (never invited) still receive the `no-invitation` error — no new accounts are created without a prior invitation

**Index page** (`pages/index.vue`):
- Adds a "Login with GitHub" button for unauthenticated visitors
- The `watchEffect` redirect is now conditional: logged-in users are only sent to `/dashboard` if they have events or are admin
- Logged-in users with no events see a message asking them to contact the organizer

**Tests** (`test/nuxt/pages.test.ts`):
- Updated assertion to match the new index page copy

## Notes

- The index page makes parallel calls to `/api/me` and `/api/admin/check` to determine redirect eligibility — failures are silently caught so the user stays on the page rather than hitting an error state.