### PR TITLE
feat: add role (participant/moderator/staff) to invitees

### DIFF
--- a/drizzle/0001_early_thunderbolt.sql
+++ b/drizzle/0001_early_thunderbolt.sql
@@ -1,0 +1,2 @@
+CREATE TYPE "public"."invitee_role" AS ENUM('participant', 'moderator', 'staff');--> statement-breakpoint
+ALTER TABLE "invitees" ADD COLUMN "role" "invitee_role" DEFAULT 'participant' NOT NULL;

--- a/drizzle/meta/0001_snapshot.json
+++ b/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,382 @@
+{
+  "id": "60334084-cecc-4203-8f77-337b5a2ad3d3",
+  "prevId": "708ab008-7df2-45bd-9065-fcc41639f8d1",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date": {
+          "name": "date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitations": {
+      "name": "invitations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "invitee_id": {
+          "name": "invitee_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invitations_invitee_id_invitees_id_fk": {
+          "name": "invitations_invitee_id_invitees_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "invitees",
+          "columnsFrom": [
+            "invitee_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invitations_token_unique": {
+          "name": "invitations_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitees": {
+      "name": "invitees",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "invitee_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'participant'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invitees_event_id_events_id_fk": {
+          "name": "invitees_event_id_events_id_fk",
+          "tableFrom": "invitees",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invitees_event_id_email_unique": {
+          "name": "invitees_event_id_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id",
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_events": {
+      "name": "user_events",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_events_user_id_users_id_fk": {
+          "name": "user_events_user_id_users_id_fk",
+          "tableFrom": "user_events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_events_event_id_events_id_fk": {
+          "name": "user_events_event_id_events_id_fk",
+          "tableFrom": "user_events",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_events_user_id_event_id_pk": {
+          "name": "user_events_user_id_event_id_pk",
+          "columns": [
+            "user_id",
+            "event_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "github_id": {
+          "name": "github_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "login": {
+          "name": "login",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_github_id_unique": {
+          "name": "users_github_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "github_id"
+          ]
+        },
+        "users_login_unique": {
+          "name": "users_login_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "login"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.invitee_role": {
+      "name": "invitee_role",
+      "schema": "public",
+      "values": [
+        "participant",
+        "moderator",
+        "staff"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1774270656660,
       "tag": "0000_watery_ender_wiggin",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1774338672318,
+      "tag": "0001_early_thunderbolt",
+      "breakpoints": true
     }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3030,22 +3030,6 @@
         "node": ">=18.12.0"
       }
     },
-    "node_modules/@nuxt/test-utils/node_modules/crossws": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/crossws/-/crossws-0.4.4.tgz",
-      "integrity": "sha512-w6c4OdpRNnudVmcgr7brb/+/HmYjMQvYToO/oTrprTwxRUiom3LYWU1PMWuD006okbUWpII1Ea9/+kwpUfmyRg==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "peerDependencies": {
-        "srvx": ">=0.7.1"
-      },
-      "peerDependenciesMeta": {
-        "srvx": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@nuxt/test-utils/node_modules/estree-walker": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
@@ -7401,17 +7385,6 @@
       "resolved": "https://registry.npmjs.org/colord/-/colord-2.9.3.tgz",
       "integrity": "sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==",
       "license": "MIT"
-    },
-    "node_modules/commander": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
-      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
     },
     "node_modules/comment-parser": {
       "version": "1.4.5",

--- a/pages/admin/events/[id]/invitees.vue
+++ b/pages/admin/events/[id]/invitees.vue
@@ -12,14 +12,29 @@ interface Invitation {
   createdAt: string
 }
 
+type InviteeRole = 'participant' | 'moderator' | 'staff'
+
 interface Invitee {
   id: string
   eventId: string
   firstName: string
   lastName: string
   email: string
+  role: InviteeRole
   createdAt: string
   invitations: Invitation[]
+}
+
+const roleOptions: { title: string; value: InviteeRole }[] = [
+  { title: 'Participant', value: 'participant' },
+  { title: 'Moderator', value: 'moderator' },
+  { title: 'Staff', value: 'staff' },
+]
+
+const roleColors: Record<InviteeRole, string> = {
+  participant: 'blue',
+  moderator: 'purple',
+  staff: 'teal',
 }
 
 interface Event {
@@ -38,6 +53,7 @@ const headers = [
   { title: 'First Name', key: 'firstName' },
   { title: 'Last Name', key: 'lastName' },
   { title: 'Email', key: 'email' },
+  { title: 'Role', key: 'role', sortable: true },
   { title: 'Invitation Status', key: 'status', sortable: false },
   { title: 'Actions', key: 'actions', sortable: false },
 ]
@@ -66,7 +82,7 @@ function getInvitationStatus(invitee: Invitee): { label: string; color: string }
 // Dialog state
 const dialog = ref(false)
 const editingInvitee = ref<Invitee | null>(null)
-const form = ref({ firstName: '', lastName: '', email: '' })
+const form = ref({ firstName: '', lastName: '', email: '', role: 'participant' as InviteeRole })
 const formValid = ref(false)
 const saving = ref(false)
 
@@ -80,7 +96,7 @@ const rules = {
 
 function openAddDialog() {
   editingInvitee.value = null
-  form.value = { firstName: '', lastName: '', email: '' }
+  form.value = { firstName: '', lastName: '', email: '', role: 'participant' }
   dialog.value = true
 }
 
@@ -90,6 +106,7 @@ function openEditDialog(invitee: Invitee) {
     firstName: invitee.firstName,
     lastName: invitee.lastName,
     email: invitee.email,
+    role: invitee.role,
   }
   dialog.value = true
 }
@@ -255,6 +272,15 @@ async function deleteInvitee() {
       items-per-page="25"
       class="elevation-1"
     >
+      <template #[`item.role`]="{ item }">
+        <v-chip
+          :color="roleColors[item.role]"
+          size="small"
+        >
+          {{ item.role }}
+        </v-chip>
+      </template>
+
       <template #[`item.status`]="{ item }">
         <v-chip
           :color="getInvitationStatus(item).color"
@@ -315,6 +341,14 @@ async function deleteInvitee() {
               label="Email"
               type="email"
               :rules="rules.email"
+              class="mb-2"
+            />
+            <v-select
+              v-model="form.role"
+              label="Role"
+              :items="roleOptions"
+              item-title="title"
+              item-value="value"
             />
           </v-form>
         </v-card-text>

--- a/server/database/schema.ts
+++ b/server/database/schema.ts
@@ -1,5 +1,6 @@
 import {
   pgTable,
+  pgEnum,
   uuid,
   varchar,
   text,
@@ -9,6 +10,11 @@ import {
   unique,
 } from 'drizzle-orm/pg-core'
 import { relations } from 'drizzle-orm'
+
+// ── Enums ───────────────────────────────────────────────────────────────────
+export const inviteeRoleValues = ['participant', 'moderator', 'staff'] as const
+export type InviteeRole = (typeof inviteeRoleValues)[number]
+export const inviteeRoleEnum = pgEnum('invitee_role', inviteeRoleValues)
 
 // ── Events ──────────────────────────────────────────────────────────────────
 export const events = pgTable('events', {
@@ -36,6 +42,7 @@ export const invitees = pgTable(
     firstName: varchar('first_name', { length: 100 }).notNull(),
     lastName: varchar('last_name', { length: 100 }).notNull(),
     email: varchar('email', { length: 255 }).notNull(),
+    role: inviteeRoleEnum('role').notNull().default('participant'),
     createdAt: timestamp('created_at', { mode: 'date' }).defaultNow().notNull(),
   },
   (t) => [unique().on(t.eventId, t.email)],

--- a/server/routes/api/events/[eventId]/invitees/[id].put.ts
+++ b/server/routes/api/events/[eventId]/invitees/[id].put.ts
@@ -1,5 +1,6 @@
 import { eq } from 'drizzle-orm'
-import { invitees } from '~/server/database/schema'
+import { invitees, inviteeRoleValues } from '~/server/database/schema'
+import type { InviteeRole } from '~/server/database/schema'
 
 export default defineEventHandler(async (event) => {
   await requireAdmin(event)
@@ -9,16 +10,21 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 400, statusMessage: 'Invitee ID is required' })
   }
 
-  const body = await readBody<{ firstName?: string; lastName?: string; email?: string }>(event)
+  const body = await readBody<{ firstName?: string; lastName?: string; email?: string; role?: InviteeRole }>(event)
 
-  if (!body.firstName && !body.lastName && !body.email) {
-    throw createError({ statusCode: 400, statusMessage: 'At least one field (firstName, lastName, email) is required' })
+  if (!body.firstName && !body.lastName && !body.email && !body.role) {
+    throw createError({ statusCode: 400, statusMessage: 'At least one field (firstName, lastName, email, role) is required' })
   }
 
-  const updates: Partial<{ firstName: string; lastName: string; email: string }> = {}
+  if (body.role && !inviteeRoleValues.includes(body.role)) {
+    throw createError({ statusCode: 400, statusMessage: `role must be one of: ${inviteeRoleValues.join(', ')}` })
+  }
+
+  const updates: Partial<{ firstName: string; lastName: string; email: string; role: InviteeRole }> = {}
   if (body.firstName) updates.firstName = body.firstName
   if (body.lastName) updates.lastName = body.lastName
   if (body.email) updates.email = body.email
+  if (body.role) updates.role = body.role
 
   const [updated] = await useDB()
     .update(invitees)

--- a/server/routes/api/events/[eventId]/invitees/index.post.ts
+++ b/server/routes/api/events/[eventId]/invitees/index.post.ts
@@ -1,4 +1,5 @@
-import { invitees } from '~/server/database/schema'
+import { invitees, inviteeRoleValues } from '~/server/database/schema'
+import type { InviteeRole } from '~/server/database/schema'
 
 export default defineEventHandler(async (event) => {
   await requireAdmin(event)
@@ -8,10 +9,14 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 400, statusMessage: 'Event ID is required' })
   }
 
-  const body = await readBody<{ firstName: string; lastName: string; email: string }>(event)
+  const body = await readBody<{ firstName: string; lastName: string; email: string; role?: InviteeRole }>(event)
 
   if (!body.firstName || !body.lastName || !body.email) {
     throw createError({ statusCode: 400, statusMessage: 'firstName, lastName, and email are required' })
+  }
+
+  if (body.role && !inviteeRoleValues.includes(body.role)) {
+    throw createError({ statusCode: 400, statusMessage: `role must be one of: ${inviteeRoleValues.join(', ')}` })
   }
 
   const [created] = await useDB()
@@ -21,6 +26,7 @@ export default defineEventHandler(async (event) => {
       firstName: body.firstName,
       lastName: body.lastName,
       email: body.email,
+      role: body.role ?? 'participant',
     })
     .returning()
 


### PR DESCRIPTION
## Motivation

Invitees in an event currently have no role distinction — everyone is treated the same. This PR introduces a **role** field so invitees can be designated as `participant`, `moderator`, or `staff`, enabling organizers to differentiate responsibilities.

## Approach

A Postgres enum (`invitee_role`) is used to constrain the allowed values at the database level. The `role` column defaults to `'participant'`, so existing data and workflows are unaffected — this is a non-breaking, additive change.

- **Schema** — New `pgEnum('invitee_role')` and a `role` column on the `invitees` table. The enum values and TypeScript type are exported for reuse across API routes.
- **Migration** — `drizzle/0001_early_thunderbolt.sql` creates the enum type and adds the column with a default.
- **API routes** — Both `POST` (create) and `PUT` (update) accept an optional `role` field with server-side validation against the allowed values.
- **Admin UI** — The invitees data table now shows a **Role** column with color-coded chips (blue/purple/teal), and the add/edit dialog includes a role selector dropdown defaulting to "Participant".

## Notes

- All 17 existing tests pass; linting is clean.
- The migration is safe to run on existing data — `DEFAULT 'participant' NOT NULL` backfills the column for existing rows.