### PR TITLE
Add CI workflow and branch ruleset to enforce tests on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  vitest:
+    name: Unit & Integration Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm test
+
+  playwright:
+    name: E2E Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+
+      - run: npx playwright install --with-deps chromium
+
+      - run: npm run test:e2e
+        env:
+          NUXT_SESSION_PASSWORD: ci-placeholder-password-at-least-32chars
+
+      - uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 14


### PR DESCRIPTION
## Why

There was no automated testing gate on pull  code could be merged into `main` without any test validation. This adds a CI pipeline and a corresponding branch ruleset to enforce that all tests pass before merging.requests 

## What this does

**GitHub Actions workflow** (`.github/workflows/ci. runs on every PR targeting `main` with two parallel jobs:yml`) 

- **Unit & Integration  runs `npm test` (Vitest), which executes unit, API, and Nuxt integration test projects. The API tests use testcontainers to spin up a PostgreSQL 17 instance automatically.Tests** 
- **E2E  installs Playwright with Chromium, runs `npm run test:e2e`, and uploads the HTML report as a build artifact (retained 14 days).Tests** 

**Branch ruleset** (configured via GitHub API, already  requires both CI jobs to pass before a PR can merge into `main`, with strict status checks enforcing the branch is up to date.active) 

## Notes

- The Vitest job relies on Docker being available on the runner for testcontainers (GitHub-hosted `ubuntu-latest` includes Docker by default).
- `NUXT_SESSION_PASSWORD` is set to a placeholder in CI since `nuxt-auth-utils` requires it at build time, but no real auth is exercised in E2E tests.
- The Playwright config already has CI-aware settings (`forbidOnly`, single worker, retries).