### PR TITLE
feat: add rooms management per event

### DIFF
--- a/drizzle/0004_rooms.sql
+++ b/drizzle/0004_rooms.sql
@@ -1,0 +1,11 @@
+CREATE TABLE "rooms" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"event_id" uuid NOT NULL,
+	"name" varchar(255) NOT NULL,
+	"description" text,
+	"capacity" integer,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "rooms" ADD CONSTRAINT "rooms_event_id_events_id_fk" FOREIGN KEY ("event_id") REFERENCES "public"."events"("id") ON DELETE cascade ON UPDATE no action;

--- a/package-lock.json
+++ b/package-lock.json
@@ -11347,7 +11347,6 @@
     },
     "node_modules/playwright/node_modules/fsevents": {
       "version": "2.3.2",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12516,7 +12515,9 @@
       "license": "ISC"
     },
     "node_modules/srvx": {
-      "version": "0.11.12",
+      "version": "0.11.15",
+      "resolved": "https://registry.npmjs.org/srvx/-/srvx-0.11.15.tgz",
+      "integrity": "sha512-iXsux0UcOjdvs0LCMa2Ws3WwcDUozA3JN3BquNXkaFPP7TpRqgunKdEgoZ/uwb1J6xaYHfxtz9Twlh6yzwM6Tg==",
       "license": "MIT",
       "bin": {
         "srvx": "bin/srvx.mjs"

--- a/pages/admin/events/[id]/rooms.vue
+++ b/pages/admin/events/[id]/rooms.vue
@@ -1,0 +1,261 @@
+<script setup lang="ts">
+definePageMeta({ middleware: 'admin' })
+
+const route = useRoute()
+const eventId = route.params.id as string
+
+interface RoomItem {
+  id: string
+  eventId: string
+  name: string
+  description: string | null
+  capacity: number | null
+  createdAt: string
+  updatedAt: string
+}
+
+interface EventInfo {
+  id: string
+  name: string
+}
+
+const { data: eventInfo } = useAsyncData(`event-${eventId}`, () =>
+  $fetch<EventInfo>(`/api/events/${eventId}`),
+)
+
+useHead({ title: () => `Rooms — ${eventInfo.value?.name ?? 'Loading...'}` })
+
+const { data: rooms, status: fetchStatus, refresh } = useAsyncData(
+  `rooms-${eventId}`,
+  () => $fetch<RoomItem[]>(`/api/events/${eventId}/rooms`),
+)
+
+const headers = [
+  { title: 'Name', key: 'name' },
+  { title: 'Description', key: 'description' },
+  { title: 'Capacity', key: 'capacity' },
+  { title: 'Actions', key: 'actions', sortable: false },
+]
+
+// ── Create / Edit dialog ───────────────────────────────────────────────────
+const dialog = ref(false)
+const editingRoom = ref<RoomItem | null>(null)
+const saving = ref(false)
+const actionError = ref('')
+
+const form = ref({
+  name: '',
+  description: '',
+  capacity: '' as string | number,
+})
+
+function openCreate() {
+  editingRoom.value = null
+  form.value = { name: '', description: '', capacity: '' }
+  actionError.value = ''
+  dialog.value = true
+}
+
+function openEdit(room: RoomItem) {
+  editingRoom.value = room
+  form.value = {
+    name: room.name,
+    description: room.description ?? '',
+    capacity: room.capacity ?? '',
+  }
+  actionError.value = ''
+  dialog.value = true
+}
+
+async function save() {
+  saving.value = true
+  actionError.value = ''
+  try {
+    const payload: Record<string, unknown> = {
+      name: form.value.name.trim(),
+      description: form.value.description.trim() || null,
+      capacity: form.value.capacity === '' ? null : Number(form.value.capacity),
+    }
+
+    if (editingRoom.value) {
+      await $fetch(`/api/events/${eventId}/rooms/${editingRoom.value.id}`, {
+        method: 'PUT',
+        body: payload,
+      })
+    } else {
+      await $fetch(`/api/events/${eventId}/rooms`, {
+        method: 'POST',
+        body: payload,
+      })
+    }
+    dialog.value = false
+    await refresh()
+  } catch (err: unknown) {
+    actionError.value = (err as { data?: { message?: string } })?.data?.message
+      ?? 'Failed to save room'
+  } finally {
+    saving.value = false
+  }
+}
+
+// ── Delete dialog ─────────────────────────────────────────────────────────
+const deleteDialog = ref(false)
+const deletingRoom = ref<RoomItem | null>(null)
+const deleting = ref(false)
+const deleteError = ref('')
+
+function openDelete(room: RoomItem) {
+  deletingRoom.value = room
+  deleteError.value = ''
+  deleteDialog.value = true
+}
+
+async function confirmDelete() {
+  if (!deletingRoom.value) return
+  deleting.value = true
+  deleteError.value = ''
+  try {
+    await $fetch(`/api/events/${eventId}/rooms/${deletingRoom.value.id}`, {
+      method: 'DELETE',
+    })
+    deleteDialog.value = false
+    await refresh()
+  } catch (err: unknown) {
+    deleteError.value = (err as { data?: { message?: string } })?.data?.message
+      ?? 'Failed to delete room'
+  } finally {
+    deleting.value = false
+  }
+}
+</script>
+
+<template>
+  <v-container>
+    <v-btn
+      variant="text"
+      to="/admin/events"
+      prepend-icon="mdi-arrow-left"
+      class="mb-4"
+    >
+      Back to Events
+    </v-btn>
+
+    <div class="d-flex align-center justify-space-between mb-4">
+      <h1 class="text-h4">
+        Rooms — {{ eventInfo?.name ?? 'Loading...' }}
+      </h1>
+      <v-btn color="primary" prepend-icon="mdi-plus" @click="openCreate">
+        Add Room
+      </v-btn>
+    </div>
+
+    <div v-if="fetchStatus === 'pending'" class="d-flex flex-column align-center pa-8">
+      <v-progress-circular indeterminate color="primary" size="48" class="mb-4" />
+      <p class="text-body-1 text-grey">Loading rooms…</p>
+    </div>
+
+    <v-alert v-else-if="fetchStatus === 'error'" type="error" variant="tonal" class="mb-4">
+      Failed to load rooms. Please try again.
+    </v-alert>
+
+    <v-data-table
+      v-else
+      :headers="headers"
+      :items="rooms ?? []"
+      :items-per-page="25"
+      class="elevation-1"
+    >
+      <template #[`item.description`]="{ item }">
+        <span v-if="item.description">{{ item.description }}</span>
+        <span v-else class="text-grey">—</span>
+      </template>
+
+      <template #[`item.capacity`]="{ item }">
+        <span v-if="item.capacity != null">{{ item.capacity }}</span>
+        <span v-else class="text-grey">—</span>
+      </template>
+
+      <template #[`item.actions`]="{ item }">
+        <v-btn icon size="small" variant="text" color="primary" @click="openEdit(item)">
+          <v-icon>mdi-pencil</v-icon>
+          <v-tooltip activator="parent" location="top">Edit</v-tooltip>
+        </v-btn>
+        <v-btn icon size="small" variant="text" color="error" @click="openDelete(item)">
+          <v-icon>mdi-delete</v-icon>
+          <v-tooltip activator="parent" location="top">Delete</v-tooltip>
+        </v-btn>
+      </template>
+    </v-data-table>
+
+    <!-- Create / Edit Dialog -->
+    <v-dialog v-model="dialog" max-width="500" persistent>
+      <v-card>
+        <v-card-title>{{ editingRoom ? 'Edit Room' : 'Add Room' }}</v-card-title>
+        <v-card-text>
+          <v-alert
+            v-if="actionError"
+            type="error"
+            variant="tonal"
+            class="mb-4"
+            closable
+            @click:close="actionError = ''"
+          >
+            {{ actionError }}
+          </v-alert>
+          <v-text-field
+            v-model="form.name"
+            label="Name"
+            :rules="[v => !!v.trim() || 'Name is required']"
+            required
+            class="mb-2"
+          />
+          <v-textarea
+            v-model="form.description"
+            label="Description"
+            rows="3"
+            class="mb-2"
+          />
+          <v-text-field
+            v-model="form.capacity"
+            label="Capacity"
+            type="number"
+            min="1"
+            hint="Leave blank if unlimited"
+            persistent-hint
+          />
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer />
+          <v-btn variant="text" :disabled="saving" @click="dialog = false">Cancel</v-btn>
+          <v-btn
+            color="primary"
+            :loading="saving"
+            :disabled="!form.name.trim()"
+            @click="save"
+          >
+            Save
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+
+    <!-- Delete Confirmation Dialog -->
+    <v-dialog v-model="deleteDialog" max-width="450">
+      <v-card>
+        <v-card-title>Delete Room</v-card-title>
+        <v-card-text>
+          <v-alert v-if="deleteError" type="error" variant="tonal" class="mb-3">
+            {{ deleteError }}
+          </v-alert>
+          Are you sure you want to delete <strong>{{ deletingRoom?.name }}</strong>?
+          This action cannot be undone.
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer />
+          <v-btn variant="text" :disabled="deleting" @click="deleteDialog = false">Cancel</v-btn>
+          <v-btn color="error" :loading="deleting" @click="confirmDelete">Delete</v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+  </v-container>
+</template>

--- a/pages/admin/events/index.vue
+++ b/pages/admin/events/index.vue
@@ -169,6 +169,16 @@ async function confirmDelete() {
           icon
           size="small"
           variant="text"
+          color="orange"
+          :to="`/admin/events/${item.id}/rooms`"
+        >
+          <v-icon>mdi-door</v-icon>
+          <v-tooltip activator="parent" location="top">Manage Rooms</v-tooltip>
+        </v-btn>
+        <v-btn
+          icon
+          size="small"
+          variant="text"
           color="secondary"
           :to="`/admin/events/${item.id}/invitees`"
         >

--- a/server/database/schema.ts
+++ b/server/database/schema.ts
@@ -36,6 +36,7 @@ export const eventsRelations = relations(events, ({ many }) => ({
   invitees: many(invitees),
   userEvents: many(userEvents),
   sessions: many(sessions),
+  rooms: many(rooms),
 }))
 
 // ── Invitees ────────────────────────────────────────────────────────────────
@@ -137,4 +138,21 @@ export const sessions = pgTable('sessions', {
 export const sessionsRelations = relations(sessions, ({ one }) => ({
   event: one(events, { fields: [sessions.eventId], references: [events.id] }),
   author: one(users, { fields: [sessions.authorId], references: [users.id] }),
+}))
+
+// ── Rooms ────────────────────────────────────────────────────────────────────
+export const rooms = pgTable('rooms', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  eventId: uuid('event_id')
+    .notNull()
+    .references(() => events.id, { onDelete: 'cascade' }),
+  name: varchar('name', { length: 255 }).notNull(),
+  description: text('description'),
+  capacity: integer('capacity'),
+  createdAt: timestamp('created_at', { mode: 'date' }).defaultNow().notNull(),
+  updatedAt: timestamp('updated_at', { mode: 'date' }).defaultNow().notNull(),
+})
+
+export const roomsRelations = relations(rooms, ({ one }) => ({
+  event: one(events, { fields: [rooms.eventId], references: [events.id] }),
 }))

--- a/server/routes/api/events/[eventId]/rooms/[roomId].delete.ts
+++ b/server/routes/api/events/[eventId]/rooms/[roomId].delete.ts
@@ -1,0 +1,31 @@
+import { eq, and } from 'drizzle-orm'
+import { rooms } from '~/server/database/schema'
+
+const logger = useLogger('rooms')
+
+export default defineEventHandler(async (event) => {
+  const eventId = getRouterParam(event, 'eventId')
+  const roomId = getRouterParam(event, 'roomId')
+
+  if (!eventId || !roomId) {
+    throw createError({ statusCode: 400, statusMessage: 'Event ID and room ID are required' })
+  }
+
+  await requireAdmin(event)
+
+  const db = useDB()
+  const [found] = await db
+    .select()
+    .from(rooms)
+    .where(and(eq(rooms.id, roomId), eq(rooms.eventId, eventId)))
+    .limit(1)
+
+  if (!found) {
+    throw createError({ statusCode: 404, statusMessage: 'Room not found' })
+  }
+
+  await db.delete(rooms).where(eq(rooms.id, roomId))
+
+  logger.info(`Room deleted: "${found.name}" (id: ${found.id}) from event ${eventId}`)
+  return { success: true }
+})

--- a/server/routes/api/events/[eventId]/rooms/[roomId].put.ts
+++ b/server/routes/api/events/[eventId]/rooms/[roomId].put.ts
@@ -1,0 +1,58 @@
+import { eq, and } from 'drizzle-orm'
+import { rooms } from '~/server/database/schema'
+
+const logger = useLogger('rooms')
+
+export default defineEventHandler(async (event) => {
+  const eventId = getRouterParam(event, 'eventId')
+  const roomId = getRouterParam(event, 'roomId')
+
+  if (!eventId || !roomId) {
+    throw createError({ statusCode: 400, statusMessage: 'Event ID and room ID are required' })
+  }
+
+  await requireAdmin(event)
+
+  const db = useDB()
+  const [found] = await db
+    .select()
+    .from(rooms)
+    .where(and(eq(rooms.id, roomId), eq(rooms.eventId, eventId)))
+    .limit(1)
+
+  if (!found) {
+    throw createError({ statusCode: 404, statusMessage: 'Room not found' })
+  }
+
+  const body = await readBody(event)
+
+  if (!body || typeof body !== 'object' || Array.isArray(body)) {
+    throw createError({ statusCode: 400, statusMessage: 'Request body must be a JSON object' })
+  }
+
+  if ('name' in body) {
+    if (typeof body.name !== 'string' || !body.name.trim()) {
+      throw createError({ statusCode: 400, statusMessage: 'name must be a non-empty string' })
+    }
+  }
+
+  if ('capacity' in body && body.capacity !== null && body.capacity !== undefined) {
+    if (!Number.isInteger(body.capacity) || body.capacity < 1) {
+      throw createError({ statusCode: 400, statusMessage: 'capacity must be a positive integer' })
+    }
+  }
+
+  const updates: Record<string, unknown> = { updatedAt: new Date() }
+  if ('name' in body) updates.name = (body.name as string).trim()
+  if ('description' in body) updates.description = body.description ?? null
+  if ('capacity' in body) updates.capacity = body.capacity ?? null
+
+  const [updated] = await db
+    .update(rooms)
+    .set(updates)
+    .where(eq(rooms.id, roomId))
+    .returning()
+
+  logger.info(`Room updated: "${updated.name}" (id: ${updated.id})`)
+  return updated
+})

--- a/server/routes/api/events/[eventId]/rooms/index.get.ts
+++ b/server/routes/api/events/[eventId]/rooms/index.get.ts
@@ -1,0 +1,23 @@
+import { eq } from 'drizzle-orm'
+import { rooms } from '~/server/database/schema'
+
+const logger = useLogger('rooms')
+
+export default defineEventHandler(async (event) => {
+  const eventId = getRouterParam(event, 'eventId')
+  if (!eventId) {
+    throw createError({ statusCode: 400, statusMessage: 'Event ID is required' })
+  }
+
+  await requireEventAccess(event, eventId)
+
+  const db = useDB()
+  const list = await db
+    .select()
+    .from(rooms)
+    .where(eq(rooms.eventId, eventId))
+    .orderBy(rooms.name)
+
+  logger.debug(`Listed ${list.length} rooms for event ${eventId}`)
+  return list
+})

--- a/server/routes/api/events/[eventId]/rooms/index.post.ts
+++ b/server/routes/api/events/[eventId]/rooms/index.post.ts
@@ -1,0 +1,43 @@
+import { rooms } from '~/server/database/schema'
+
+const logger = useLogger('rooms')
+
+export default defineEventHandler(async (event) => {
+  const eventId = getRouterParam(event, 'eventId')
+  if (!eventId) {
+    throw createError({ statusCode: 400, statusMessage: 'Event ID is required' })
+  }
+
+  await requireAdmin(event)
+
+  const body = await readBody<{
+    name: string
+    description?: string
+    capacity?: number
+  }>(event)
+
+  if (!body?.name?.trim()) {
+    throw createError({ statusCode: 400, statusMessage: 'name is required' })
+  }
+
+  if (body.capacity !== undefined && body.capacity !== null) {
+    if (!Number.isInteger(body.capacity) || body.capacity < 1) {
+      throw createError({ statusCode: 400, statusMessage: 'capacity must be a positive integer' })
+    }
+  }
+
+  const db = useDB()
+  const [created] = await db
+    .insert(rooms)
+    .values({
+      eventId,
+      name: body.name.trim(),
+      description: body.description ?? null,
+      capacity: body.capacity ?? null,
+    })
+    .returning()
+
+  logger.info(`Room created: "${created.name}" (id: ${created.id}) in event ${eventId}`)
+  setResponseStatus(event, 201)
+  return created
+})

--- a/test/api/helpers.ts
+++ b/test/api/helpers.ts
@@ -20,6 +20,7 @@ export async function migrateAndSeed() {
 
   // Drop all tables and custom types so migrations are idempotent across test files
   await client.unsafe(`
+    DROP TABLE IF EXISTS rooms CASCADE;
     DROP TABLE IF EXISTS sessions CASCADE;
     DROP TABLE IF EXISTS user_events CASCADE;
     DROP TABLE IF EXISTS invitations CASCADE;
@@ -75,6 +76,8 @@ export async function migrateAndSeed() {
     })),
   )
 
+  await db.insert(schema.rooms).values(loadJson('rooms.json'))
+
   await client.end()
 }
 
@@ -102,6 +105,11 @@ export const TEST_SESSION_SCHEDULED_ID = 'd0000000-0000-0000-0000-000000000003'
 export const TEST_SESSION_DELIVERED_ID = 'd0000000-0000-0000-0000-000000000004'
 export const TEST_SESSION_PROPOSED_BY_NOAH_ID = 'd0000000-0000-0000-0000-000000000005'
 export const TEST_SESSION_STAFF_PUBLISHED_ID = 'd0000000-0000-0000-0000-000000000006'
+
+// Room fixture IDs
+export const TEST_ROOM_MAIN_HALL_ID = 'e0000000-0000-0000-0000-000000000001'
+export const TEST_ROOM_WORKSHOP_A_ID = 'e0000000-0000-0000-0000-000000000002'
+export const TEST_ROOM_BREAKOUT_ID = 'e0000000-0000-0000-0000-000000000003'
 
 // Additional user emails for test logins
 export const STAFF_USER_EMAIL = 'liam.obrien@example.com'

--- a/test/api/rooms.test.ts
+++ b/test/api/rooms.test.ts
@@ -1,0 +1,278 @@
+import { describe, it, expect, beforeAll } from 'vitest'
+import { setup, fetch } from '@nuxt/test-utils/e2e'
+import { fileURLToPath } from 'node:url'
+import {
+  migrateAndSeed,
+  loginAs,
+  ADMIN_EMAIL,
+  REGULAR_USER_EMAIL,
+  OUTSIDER_EMAIL,
+  TEST_EVENT_ID,
+  TEST_ROOM_MAIN_HALL_ID,
+  TEST_ROOM_WORKSHOP_A_ID,
+} from './helpers'
+
+const BASE = `/api/events/${TEST_EVENT_ID}/rooms`
+
+describe('Rooms Endpoints', async () => {
+  let adminCookies: string
+  let userCookies: string
+
+  await setup({
+    rootDir: fileURLToPath(new URL('../..', import.meta.url)),
+    env: {
+      AUTH_MODE: 'local',
+      NUXT_AUTH_MODE: 'local',
+      NUXT_PUBLIC_AUTH_MODE: 'local',
+      ADMIN_EMAILS: ADMIN_EMAIL,
+      NUXT_SESSION_PASSWORD: 'test-session-secret-that-is-at-least-32-chars-long',
+      SMTP_HOST: 'localhost',
+      SMTP_PORT: '2525',
+      APP_URL: 'http://localhost:3000',
+    },
+  })
+
+  beforeAll(async () => {
+    await migrateAndSeed()
+    adminCookies = await loginAs(fetch, ADMIN_EMAIL)
+    userCookies = await loginAs(fetch, REGULAR_USER_EMAIL)
+  })
+
+  // ─── GET /rooms ────────────────────────────────────────────────────────────
+
+  describe('GET /api/events/[eventId]/rooms', () => {
+    it('returns 401 for unauthenticated request', async () => {
+      const res = await fetch(BASE)
+      expect(res.status).toBe(401)
+    })
+
+    it('returns 403 for user not in the event', async () => {
+      const outsiderCookies = await loginAs(fetch, OUTSIDER_EMAIL)
+      const res = await fetch(BASE, { headers: { Cookie: outsiderCookies } })
+      expect(res.status).toBe(403)
+    })
+
+    it('returns 200 with rooms list for event member', async () => {
+      const res = await fetch(BASE, { headers: { Cookie: userCookies } })
+      expect(res.status).toBe(200)
+      const list = await res.json() as Array<{ id: string; name: string }>
+      expect(Array.isArray(list)).toBe(true)
+      expect(list.length).toBeGreaterThanOrEqual(3)
+    })
+
+    it('returns rooms sorted by name', async () => {
+      const res = await fetch(BASE, { headers: { Cookie: adminCookies } })
+      expect(res.status).toBe(200)
+      const list = await res.json() as Array<{ name: string }>
+      const names = list.map(r => r.name)
+      expect(names).toEqual([...names].sort())
+    })
+
+    it('includes expected fields on each room', async () => {
+      const res = await fetch(BASE, { headers: { Cookie: adminCookies } })
+      const list = await res.json() as Array<Record<string, unknown>>
+      const room = list.find(r => r.id === TEST_ROOM_MAIN_HALL_ID)
+      expect(room).toBeDefined()
+      expect(room!.name).toBe('Main Hall')
+      expect(room!.capacity).toBe(200)
+      expect(room!.eventId).toBe(TEST_EVENT_ID)
+    })
+  })
+
+  // ─── POST /rooms ───────────────────────────────────────────────────────────
+
+  describe('POST /api/events/[eventId]/rooms', () => {
+    it('returns 401 for unauthenticated request', async () => {
+      const res = await fetch(BASE, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: 'New Room' }),
+      })
+      expect(res.status).toBe(401)
+    })
+
+    it('returns 403 for non-admin user', async () => {
+      const res = await fetch(BASE, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Cookie: userCookies },
+        body: JSON.stringify({ name: 'New Room' }),
+      })
+      expect(res.status).toBe(403)
+    })
+
+    it('returns 400 when name is missing', async () => {
+      const res = await fetch(BASE, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Cookie: adminCookies },
+        body: JSON.stringify({ description: 'No name here' }),
+      })
+      expect(res.status).toBe(400)
+    })
+
+    it('returns 400 for invalid capacity (non-integer)', async () => {
+      const res = await fetch(BASE, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Cookie: adminCookies },
+        body: JSON.stringify({ name: 'Bad Room', capacity: 1.5 }),
+      })
+      expect(res.status).toBe(400)
+    })
+
+    it('returns 400 for capacity less than 1', async () => {
+      const res = await fetch(BASE, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Cookie: adminCookies },
+        body: JSON.stringify({ name: 'Zero Cap', capacity: 0 }),
+      })
+      expect(res.status).toBe(400)
+    })
+
+    it('creates a room with full fields and returns 201', async () => {
+      const res = await fetch(BASE, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Cookie: adminCookies },
+        body: JSON.stringify({ name: 'Conference Room B', description: 'Boardroom style', capacity: 12 }),
+      })
+      expect(res.status).toBe(201)
+      const room = await res.json() as Record<string, unknown>
+      expect(room.name).toBe('Conference Room B')
+      expect(room.description).toBe('Boardroom style')
+      expect(room.capacity).toBe(12)
+      expect(room.id).toBeDefined()
+      expect(room.eventId).toBe(TEST_EVENT_ID)
+
+      // Cleanup — delete the created room
+      await fetch(`${BASE}/${room.id}`, { method: 'DELETE', headers: { Cookie: adminCookies } })
+    })
+
+    it('creates a room without optional fields', async () => {
+      const res = await fetch(BASE, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Cookie: adminCookies },
+        body: JSON.stringify({ name: 'Minimal Room' }),
+      })
+      expect(res.status).toBe(201)
+      const room = await res.json() as Record<string, unknown>
+      expect(room.name).toBe('Minimal Room')
+      expect(room.description).toBeNull()
+      expect(room.capacity).toBeNull()
+
+      // Cleanup
+      await fetch(`${BASE}/${room.id}`, { method: 'DELETE', headers: { Cookie: adminCookies } })
+    })
+  })
+
+  // ─── PUT /rooms/[roomId] ───────────────────────────────────────────────────
+
+  describe('PUT /api/events/[eventId]/rooms/[roomId]', () => {
+    it('returns 401 for unauthenticated request', async () => {
+      const res = await fetch(`${BASE}/${TEST_ROOM_WORKSHOP_A_ID}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name: 'Updated' }),
+      })
+      expect(res.status).toBe(401)
+    })
+
+    it('returns 403 for non-admin user', async () => {
+      const res = await fetch(`${BASE}/${TEST_ROOM_WORKSHOP_A_ID}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json', Cookie: userCookies },
+        body: JSON.stringify({ name: 'Updated' }),
+      })
+      expect(res.status).toBe(403)
+    })
+
+    it('returns 404 for unknown room ID', async () => {
+      const res = await fetch(`${BASE}/00000000-0000-0000-0000-000000000000`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json', Cookie: adminCookies },
+        body: JSON.stringify({ name: 'Ghost' }),
+      })
+      expect(res.status).toBe(404)
+    })
+
+    it('returns 400 when name is an empty string', async () => {
+      const res = await fetch(`${BASE}/${TEST_ROOM_WORKSHOP_A_ID}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json', Cookie: adminCookies },
+        body: JSON.stringify({ name: '   ' }),
+      })
+      expect(res.status).toBe(400)
+    })
+
+    it('updates a room and verifies via GET', async () => {
+      const res = await fetch(`${BASE}/${TEST_ROOM_WORKSHOP_A_ID}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json', Cookie: adminCookies },
+        body: JSON.stringify({ name: 'Workshop Room A (Updated)', capacity: 25 }),
+      })
+      expect(res.status).toBe(200)
+      const updated = await res.json() as Record<string, unknown>
+      expect(updated.name).toBe('Workshop Room A (Updated)')
+      expect(updated.capacity).toBe(25)
+
+      // Verify via GET
+      const listRes = await fetch(BASE, { headers: { Cookie: adminCookies } })
+      const list = await listRes.json() as Array<Record<string, unknown>>
+      const found = list.find(r => r.id === TEST_ROOM_WORKSHOP_A_ID)
+      expect(found?.name).toBe('Workshop Room A (Updated)')
+
+      // Restore original values
+      await fetch(`${BASE}/${TEST_ROOM_WORKSHOP_A_ID}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json', Cookie: adminCookies },
+        body: JSON.stringify({ name: 'Workshop Room A', capacity: 30 }),
+      })
+    })
+  })
+
+  // ─── DELETE /rooms/[roomId] ────────────────────────────────────────────────
+
+  describe('DELETE /api/events/[eventId]/rooms/[roomId]', () => {
+    it('returns 401 for unauthenticated request', async () => {
+      const res = await fetch(`${BASE}/${TEST_ROOM_MAIN_HALL_ID}`, { method: 'DELETE' })
+      expect(res.status).toBe(401)
+    })
+
+    it('returns 403 for non-admin user', async () => {
+      const res = await fetch(`${BASE}/${TEST_ROOM_MAIN_HALL_ID}`, {
+        method: 'DELETE',
+        headers: { Cookie: userCookies },
+      })
+      expect(res.status).toBe(403)
+    })
+
+    it('returns 404 for unknown room ID', async () => {
+      const res = await fetch(`${BASE}/00000000-0000-0000-0000-000000000000`, {
+        method: 'DELETE',
+        headers: { Cookie: adminCookies },
+      })
+      expect(res.status).toBe(404)
+    })
+
+    it('deletes a room and verifies via GET', async () => {
+      // First create a room to delete
+      const createRes = await fetch(BASE, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Cookie: adminCookies },
+        body: JSON.stringify({ name: 'Temp Room' }),
+      })
+      expect(createRes.status).toBe(201)
+      const { id } = await createRes.json() as { id: string }
+
+      const deleteRes = await fetch(`${BASE}/${id}`, {
+        method: 'DELETE',
+        headers: { Cookie: adminCookies },
+      })
+      expect(deleteRes.status).toBe(200)
+      const body = await deleteRes.json() as { success: boolean }
+      expect(body.success).toBe(true)
+
+      // Verify it's gone
+      const listRes = await fetch(BASE, { headers: { Cookie: adminCookies } })
+      const list = await listRes.json() as Array<{ id: string }>
+      expect(list.find(r => r.id === id)).toBeUndefined()
+    })
+  })
+})

--- a/test/db/rooms.json
+++ b/test/db/rooms.json
@@ -1,0 +1,23 @@
+[
+  {
+    "id": "e0000000-0000-0000-0000-000000000001",
+    "eventId": "a0000000-0000-0000-0000-000000000001",
+    "name": "Main Hall",
+    "description": "Large auditorium with projector and stage.",
+    "capacity": 200
+  },
+  {
+    "id": "e0000000-0000-0000-0000-000000000002",
+    "eventId": "a0000000-0000-0000-0000-000000000001",
+    "name": "Workshop Room A",
+    "description": "Small room suitable for hands-on workshops.",
+    "capacity": 30
+  },
+  {
+    "id": "e0000000-0000-0000-0000-000000000003",
+    "eventId": "a0000000-0000-0000-0000-000000000001",
+    "name": "Breakout Space",
+    "description": null,
+    "capacity": null
+  }
+]


### PR DESCRIPTION
## Why

Admins need to configure the physical spaces available for an event. Without room data, session scheduling has no way to associate talks with locations. This PR introduces a `rooms` resource nested under events, allowing admins to define rooms with a name, optional description, and optional capacity.

## What changed

**Database**
- New migration `drizzle/0004_rooms.sql` creates the `rooms` table (UUID PK, `event_id` FK with cascade delete, `name`, `description`, `capacity`).
- `server/database/schema.ts` updated with the Drizzle ORM `rooms` table definition and a `rooms` relation on `events`.

**API** - 4 new endpoints under `/api/events/[eventId]/rooms`:
- `GET` -- list rooms, accessible to any authenticated event member (admin, staff, participant)
- `POST` -- create a room; admin only; validates that `name` is present and `capacity` (if provided) is a positive integer
- `PUT /[roomId]` -- partial update; admin only; 404 on unknown room
- `DELETE /[roomId]` -- delete; admin only; 404 on unknown room

**Tests**
- `test/db/rooms.json` -- 3 fixture rooms tied to the existing test event
- `test/api/helpers.ts` -- seeds rooms table and exports `TEST_ROOM_*` constants
- `test/api/rooms.test.ts` -- full integration coverage: 401, 403, 200/201, 400 validation, 404, and mutation round-trips

**Admin UI**
- `pages/admin/events/[id]/rooms.vue` -- CRUD management page with create/edit/delete dialogs
- Rooms icon button added to the events list in `pages/admin/events/index.vue`

## Notes
- `capacity` and `description` are optional (nullable).
- Room listing is open to all event members for future participant-facing schedule features.
- Session-to-room assignment is out of scope for this PR.