### PR TITLE
Add Rooms and Edit links to admin event cards on dashboard

### DIFF
--- a/pages/dashboard.vue
+++ b/pages/dashboard.vue
@@ -122,6 +122,24 @@ watch(
                 >
                   Sessions
                 </v-btn>
+                <v-btn
+                  size="small"
+                  variant="text"
+                  color="deep-purple"
+                  :to="`/admin/events/${ev.id}/rooms`"
+                  prepend-icon="mdi-door"
+                >
+                  Rooms
+                </v-btn>
+                <v-btn
+                  size="small"
+                  variant="text"
+                  color="primary"
+                  to="/admin/events"
+                  prepend-icon="mdi-pencil"
+                >
+                  Edit
+                </v-btn>
               </v-card-actions>
             </v-card>
           </v-col>


### PR DESCRIPTION
As an admin, the event cards on the dashboard were missing quick-access links to two actions available elsewhere in the admin UI: managing rooms and editing the event.

This adds two buttons to each admin event card:

- **Rooms** -- links to `/admin/events/{id}/rooms`, matching the icon and color used on the Manage Events page
- **Edit** -- links to `/admin/events`, where the edit dialog lives (there is no dedicated per-event edit route)

No new features or API changes -- purely navigation links to existing pages.