### PR TITLE
fix: run migrations before seeding in seed.ts

### DIFF
--- a/server/database/seed.ts
+++ b/server/database/seed.ts
@@ -1,4 +1,5 @@
 import { drizzle } from 'drizzle-orm/postgres-js'
+import { migrate } from 'drizzle-orm/postgres-js/migrator'
 import postgres from 'postgres'
 import { readFileSync } from 'node:fs'
 import { resolve, dirname } from 'node:path'
@@ -20,6 +21,8 @@ const db = drizzle(client, { schema })
 
 async function seed() {
   logger.info('Seeding database...')
+
+  await migrate(db, { migrationsFolder: resolve(__dirname, '../../drizzle') })
 
   await db.insert(schema.events).values(
     loadJson('events.json').map((e: Record<string, unknown>) => ({ ...e, date: new Date(e.date as string) })),


### PR DESCRIPTION
The seed script was failing because pending migrations (adding `submission_restricted`, `min_stars`, and `max_stars` columns to the `events` table) had not been applied before it attempted to insert data. As a side effect, the `rooms` table was always left empty since the insert never ran.

The fix adds a `migrate()` call at the start of `seed()`, so the script applies all pending migrations before inserting any data. This makes `npm run db:seed` self-contained -- no need to remember to run `npm run db:migrate` separately beforehand.