### PR TITLE
feat: session types, durations, and type filters

### DIFF
--- a/drizzle/0006_session_type_duration.sql
+++ b/drizzle/0006_session_type_duration.sql
@@ -1,0 +1,5 @@
+CREATE TYPE "public"."session_type" AS ENUM('discussion', 'workshop');--> statement-breakpoint
+ALTER TABLE "sessions" ADD COLUMN "type" "session_type" NOT NULL DEFAULT 'discussion';--> statement-breakpoint
+ALTER TABLE "sessions" ADD COLUMN "duration" integer;--> statement-breakpoint
+ALTER TABLE "events" ADD COLUMN "default_discussion_duration" integer NOT NULL DEFAULT 30;--> statement-breakpoint
+ALTER TABLE "events" ADD COLUMN "default_workshop_duration" integer NOT NULL DEFAULT 75;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1746349200000,
       "tag": "0005_rooms",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1746612000000,
+      "tag": "0006_session_type_duration",
+      "breakpoints": true
     }
   ]
 }

--- a/pages/admin/events/[id]/sessions.vue
+++ b/pages/admin/events/[id]/sessions.vue
@@ -5,6 +5,7 @@ const route = useRoute()
 const eventId = route.params.id as string
 
 type SessionStatus = 'proposed' | 'published' | 'scheduled' | 'delivered'
+type SessionType = 'discussion' | 'workshop'
 
 interface SessionItem {
   id: string
@@ -17,6 +18,8 @@ interface SessionItem {
   description: string | null
   tags: string[]
   status: SessionStatus
+  type: SessionType
+  duration: number | null
   starCount: number
   createdAt: string
   updatedAt: string
@@ -25,6 +28,8 @@ interface SessionItem {
 interface EventInfo {
   id: string
   name: string
+  defaultDiscussionDuration: number
+  defaultWorkshopDuration: number
 }
 
 const statusOptions: { title: string; value: SessionStatus }[] = [
@@ -68,6 +73,8 @@ const filteredSessions = computed(() => {
 const headers = [
   { title: 'Title', key: 'title' },
   { title: 'Author', key: 'author', sortable: false },
+  { title: 'Type', key: 'type', sortable: false },
+  { title: 'Duration', key: 'duration', sortable: false },
   { title: 'Status', key: 'status' },
   { title: 'Stars', key: 'starCount', sortable: true },
   { title: 'Tags', key: 'tags', sortable: false },
@@ -89,13 +96,15 @@ const form = ref({
   description: '',
   tags: '' as string,
   status: 'proposed' as SessionStatus,
+  type: 'discussion' as SessionType,
+  duration: null as number | null,
 })
 
 const actionError = ref('')
 
 function openCreate() {
   editingSession.value = null
-  form.value = { title: '', description: '', tags: '', status: 'proposed' }
+  form.value = { title: '', description: '', tags: '', status: 'proposed', type: 'discussion', duration: null }
   actionError.value = ''
   dialog.value = true
 }
@@ -107,6 +116,8 @@ function openEdit(session: SessionItem) {
     description: session.description ?? '',
     tags: session.tags.join(', '),
     status: session.status,
+    type: session.type,
+    duration: session.duration,
   }
   actionError.value = ''
   dialog.value = true
@@ -129,6 +140,8 @@ async function save() {
       description: form.value.description.trim() || null,
       tags: parseTags(form.value.tags),
       status: form.value.status,
+      type: form.value.type,
+      duration: form.value.duration ?? undefined,
     }
     if (editingSession.value) {
       await $fetch(`/api/events/${eventId}/sessions/${editingSession.value.id}`, {
@@ -152,7 +165,15 @@ async function save() {
   }
 }
 
-// ── Delete dialog ─────────────────────────────────────────────────────────────
+function effectiveDuration(session: SessionItem): string {
+  if (session.duration !== null) return `${session.duration} min`
+  if (!eventInfo.value) return '—'
+  const def = session.type === 'workshop'
+    ? eventInfo.value.defaultWorkshopDuration
+    : eventInfo.value.defaultDiscussionDuration
+  return `${def} min (default)`
+}
+
 const deleteDialog = ref(false)
 const deletingSession = ref<SessionItem | null>(null)
 const deleting = ref(false)
@@ -246,6 +267,20 @@ async function confirmDelete() {
       :items-per-page="25"
       class="elevation-1"
     >
+      <template #[`item.type`]="{ item }">
+        <v-chip
+          :color="item.type === 'workshop' ? 'orange' : 'blue'"
+          size="small"
+          variant="tonal"
+        >
+          {{ item.type }}
+        </v-chip>
+      </template>
+
+      <template #[`item.duration`]="{ item }">
+        {{ effectiveDuration(item) }}
+      </template>
+
       <template #[`item.status`]="{ item }">
         <v-chip :color="statusColors[item.status]" size="small">
           {{ item.status }}
@@ -327,6 +362,23 @@ async function confirmDelete() {
             :items="statusOptions"
             item-title="title"
             item-value="value"
+            class="mb-2"
+          />
+          <v-select
+            v-model="form.type"
+            label="Session Type"
+            :items="[{ title: 'Discussion', value: 'discussion' }, { title: 'Workshop', value: 'workshop' }]"
+            item-title="title"
+            item-value="value"
+            class="mb-2"
+          />
+          <v-text-field
+            v-model.number="form.duration"
+            label="Duration (minutes) — leave blank to use event default"
+            type="number"
+            :min="1"
+            clearable
+            class="mb-2"
           />
         </v-card-text>
         <v-card-actions>

--- a/pages/admin/events/index.vue
+++ b/pages/admin/events/index.vue
@@ -10,6 +10,8 @@ interface EventItem {
   submissionRestricted: boolean
   minStars: number
   maxStars: number
+  defaultDiscussionDuration: number
+  defaultWorkshopDuration: number
   createdAt: string
   updatedAt: string
   inviteeCount: number
@@ -43,6 +45,8 @@ const form = ref({
   submissionRestricted: false,
   minStars: 4,
   maxStars: 6,
+  defaultDiscussionDuration: 30,
+  defaultWorkshopDuration: 75,
 })
 
 function formatDate(date: string | null): string {
@@ -61,7 +65,7 @@ function truncate(text: string | null, length = 80): string {
 
 function openCreate() {
   editingEvent.value = null
-  form.value = { name: '', description: '', date: '', submissionRestricted: false, minStars: 4, maxStars: 6 }
+  form.value = { name: '', description: '', date: '', submissionRestricted: false, minStars: 4, maxStars: 6, defaultDiscussionDuration: 30, defaultWorkshopDuration: 75 }
   actionError.value = ''
   dialog.value = true
 }
@@ -75,6 +79,8 @@ function openEdit(event: EventItem) {
     submissionRestricted: event.submissionRestricted,
     minStars: event.minStars,
     maxStars: event.maxStars,
+    defaultDiscussionDuration: event.defaultDiscussionDuration,
+    defaultWorkshopDuration: event.defaultWorkshopDuration,
   }
   actionError.value = ''
   dialog.value = true
@@ -103,6 +109,8 @@ async function save() {
       submissionRestricted: form.value.submissionRestricted,
       minStars: form.value.minStars,
       maxStars: form.value.maxStars,
+      defaultDiscussionDuration: form.value.defaultDiscussionDuration,
+      defaultWorkshopDuration: form.value.defaultWorkshopDuration,
     }
 
     if (editingEvent.value) {
@@ -256,6 +264,22 @@ async function confirmDelete() {
             <v-text-field
               v-model.number="form.maxStars"
               label="Maximum stars per participant"
+              type="number"
+              :min="1"
+              style="flex: 1"
+            />
+          </div>
+          <div class="d-flex ga-4 mt-2">
+            <v-text-field
+              v-model.number="form.defaultDiscussionDuration"
+              label="Default discussion duration (min)"
+              type="number"
+              :min="1"
+              style="flex: 1"
+            />
+            <v-text-field
+              v-model.number="form.defaultWorkshopDuration"
+              label="Default workshop duration (min)"
               type="number"
               :min="1"
               style="flex: 1"

--- a/pages/events/[id].vue
+++ b/pages/events/[id].vue
@@ -35,6 +35,7 @@ const eventId = route.params.id as string
 
 const { user } = useUserSession()
 const includeDelivered = ref(false)
+const typeFilter = ref<SessionType | null>(null)
 
 const { data: eventDetail, status: eventStatus, error: eventError } = useFetch<EventDetail>(
   `/api/events/${eventId}`,
@@ -50,6 +51,12 @@ const {
 })
 
 useHead(computed(() => ({ title: eventDetail.value?.name ?? 'Event' })))
+
+const filteredSessions = computed(() => {
+  if (!sessions.value) return []
+  if (!typeFilter.value) return sessions.value
+  return sessions.value.filter(s => s.type === typeFilter.value)
+})
 
 // ── Propose session dialog ────────────────────────────────────────────────────
 const proposeOpen = ref(false)
@@ -222,7 +229,7 @@ function effectiveDuration(session: SessionRow): string {
       </div>
 
       <!-- Filter bar -->
-      <div class="d-flex align-center mb-5">
+      <div class="d-flex align-center flex-wrap ga-3 mb-5">
         <v-switch
           v-model="includeDelivered"
           label="Show delivered sessions"
@@ -230,6 +237,36 @@ function effectiveDuration(session: SessionRow): string {
           density="compact"
           color="primary"
         />
+        <v-divider vertical class="mx-1" style="height:24px" />
+        <v-chip
+          :variant="typeFilter === null ? 'flat' : 'outlined'"
+          :color="typeFilter === null ? 'primary' : undefined"
+          size="small"
+          clickable
+          @click="typeFilter = null"
+        >
+          All types
+        </v-chip>
+        <v-chip
+          :variant="typeFilter === 'discussion' ? 'flat' : 'outlined'"
+          :color="typeFilter === 'discussion' ? 'teal' : undefined"
+          size="small"
+          clickable
+          @click="typeFilter = typeFilter === 'discussion' ? null : 'discussion'"
+        >
+          <v-icon start size="x-small">mdi-forum-outline</v-icon>
+          Discussion
+        </v-chip>
+        <v-chip
+          :variant="typeFilter === 'workshop' ? 'flat' : 'outlined'"
+          :color="typeFilter === 'workshop' ? 'orange' : undefined"
+          size="small"
+          clickable
+          @click="typeFilter = typeFilter === 'workshop' ? null : 'workshop'"
+        >
+          <v-icon start size="x-small">mdi-tools</v-icon>
+          Workshop
+        </v-chip>
       </div>
 
       <!-- Sessions loading -->
@@ -239,7 +276,7 @@ function effectiveDuration(session: SessionRow): string {
       <template v-else-if="sessions && sessions.length > 0">
         <v-row>
           <v-col
-            v-for="session in sessions"
+            v-for="session in filteredSessions"
             :key="session.id"
             cols="12"
             sm="6"
@@ -320,7 +357,8 @@ function effectiveDuration(session: SessionRow): string {
       </template>
 
       <v-alert v-else type="info" variant="tonal" max-width="600">
-        No sessions yet.
+        <span v-if="typeFilter">No <strong>{{ typeFilter }}</strong> sessions found.</span>
+        <span v-else>No sessions yet.</span>
         <template v-if="!includeDelivered">
           <v-btn variant="text" size="small" @click="includeDelivered = true">Show delivered sessions</v-btn>
         </template>

--- a/pages/events/[id].vue
+++ b/pages/events/[id].vue
@@ -7,7 +7,11 @@ interface EventDetail {
   description: string | null
   date: string | null
   submissionRestricted: boolean
+  defaultDiscussionDuration: number
+  defaultWorkshopDuration: number
 }
+
+type SessionType = 'discussion' | 'workshop'
 
 interface SessionRow {
   id: string
@@ -20,6 +24,8 @@ interface SessionRow {
   description: string | null
   tags: string[]
   status: 'proposed' | 'published' | 'scheduled' | 'delivered'
+  type: SessionType
+  duration: number | null
   createdAt: string
   updatedAt: string
 }
@@ -150,6 +156,15 @@ function statusColor(status: SessionRow['status']) {
     default: return 'default'
   }
 }
+
+function effectiveDuration(session: SessionRow): string {
+  if (session.duration !== null) return `${session.duration} min`
+  if (!eventDetail.value) return '—'
+  const def = session.type === 'workshop'
+    ? eventDetail.value.defaultWorkshopDuration
+    : eventDetail.value.defaultDiscussionDuration
+  return `${def} min`
+}
 </script>
 
 <template>
@@ -248,6 +263,17 @@ function statusColor(status: SessionRow['status']) {
                 >
                   {{ session.status }}
                 </v-chip>
+                <v-chip
+                  :color="session.type === 'workshop' ? 'orange' : 'teal'"
+                  size="x-small"
+                  variant="tonal"
+                  class="mr-1"
+                >
+                  {{ session.type }}
+                </v-chip>
+                <span class="text-caption text-medium-emphasis mr-2">
+                  <v-icon size="x-small" class="mr-1">mdi-clock-outline</v-icon>{{ effectiveDuration(session) }}
+                </span>
                 <span v-if="isMySession(session)" class="text-caption text-primary font-weight-medium">My proposal</span>
               </v-card-subtitle>
 

--- a/pages/events/[id]/sessions.vue
+++ b/pages/events/[id]/sessions.vue
@@ -56,11 +56,13 @@ const { data: sessions, status: fetchStatus, refresh } = useAsyncData(
 
 // ── Starred filter ──────────────────────────────────────────────────────────
 const showStarredOnly = ref(false)
+const typeFilter = ref<'discussion' | 'workshop' | null>(null)
 
 const filteredSessions = computed(() => {
-  if (!sessions.value) return []
-  if (showStarredOnly.value) return sessions.value.filter(s => s.isStarred)
-  return sessions.value
+  let result = sessions.value ?? []
+  if (showStarredOnly.value) result = result.filter(s => s.isStarred)
+  if (typeFilter.value) result = result.filter(s => s.type === typeFilter.value)
+  return result
 })
 
 // ── Star budget ─────────────────────────────────────────────────────────────
@@ -137,8 +139,8 @@ function effectiveDuration(session: SessionItem): string {
       </div>
     </div>
 
-    <!-- Starred-only toggle -->
-    <div class="d-flex align-center ga-3 mb-4">
+    <!-- Filters -->
+    <div class="d-flex flex-wrap align-center ga-2 mb-4">
       <v-btn
         :color="showStarredOnly ? 'amber-darken-2' : undefined"
         :variant="showStarredOnly ? 'flat' : 'outlined'"
@@ -148,15 +150,38 @@ function effectiveDuration(session: SessionItem): string {
       >
         Starred only
       </v-btn>
-      <v-btn
-        v-if="showStarredOnly"
+
+      <v-divider vertical class="mx-1" style="height:24px" />
+
+      <v-chip
+        :variant="typeFilter === null ? 'flat' : 'outlined'"
+        :color="typeFilter === null ? 'primary' : undefined"
         size="small"
-        variant="text"
-        color="grey"
-        @click="showStarredOnly = false"
+        clickable
+        @click="typeFilter = null"
       >
-        Show all
-      </v-btn>
+        All types
+      </v-chip>
+      <v-chip
+        :variant="typeFilter === 'discussion' ? 'flat' : 'outlined'"
+        :color="typeFilter === 'discussion' ? 'teal' : undefined"
+        size="small"
+        clickable
+        @click="typeFilter = typeFilter === 'discussion' ? null : 'discussion'"
+      >
+        <v-icon start size="x-small">mdi-forum-outline</v-icon>
+        Discussion
+      </v-chip>
+      <v-chip
+        :variant="typeFilter === 'workshop' ? 'flat' : 'outlined'"
+        :color="typeFilter === 'workshop' ? 'orange' : undefined"
+        size="small"
+        clickable
+        @click="typeFilter = typeFilter === 'workshop' ? null : 'workshop'"
+      >
+        <v-icon start size="x-small">mdi-tools</v-icon>
+        Workshop
+      </v-chip>
     </div>
 
     <v-alert
@@ -185,7 +210,10 @@ function effectiveDuration(session: SessionItem): string {
         type="info"
         variant="tonal"
       >
-        {{ showStarredOnly ? 'You have not starred any sessions yet.' : 'No sessions available.' }}
+        <span v-if="showStarredOnly && typeFilter">No starred {{ typeFilter }} sessions.</span>
+        <span v-else-if="showStarredOnly">You have not starred any sessions yet.</span>
+        <span v-else-if="typeFilter">No {{ typeFilter }} sessions available.</span>
+        <span v-else>No sessions available.</span>
       </v-alert>
 
       <v-row v-else>

--- a/pages/events/[id]/sessions.vue
+++ b/pages/events/[id]/sessions.vue
@@ -5,6 +5,7 @@ const route = useRoute()
 const eventId = route.params.id as string
 
 type SessionStatus = 'proposed' | 'published' | 'scheduled' | 'delivered'
+type SessionType = 'discussion' | 'workshop'
 
 interface SessionItem {
   id: string
@@ -17,6 +18,8 @@ interface SessionItem {
   description: string | null
   tags: string[]
   status: SessionStatus
+  type: SessionType
+  duration: number | null
   starCount: number
   isStarred: boolean
   createdAt: string
@@ -28,6 +31,8 @@ interface EventInfo {
   name: string
   minStars: number
   maxStars: number
+  defaultDiscussionDuration: number
+  defaultWorkshopDuration: number
 }
 
 const statusColors: Record<SessionStatus, string> = {
@@ -91,6 +96,15 @@ async function toggleStar(session: SessionItem) {
 function authorName(session: SessionItem): string {
   const parts = [session.authorFirstName, session.authorLastName].filter(Boolean)
   return parts.length ? parts.join(' ') : (session.authorEmail ?? 'Unknown')
+}
+
+function effectiveDuration(session: SessionItem): string {
+  if (session.duration !== null) return `${session.duration} min`
+  if (!eventInfo.value) return '—'
+  const def = session.type === 'workshop'
+    ? eventInfo.value.defaultWorkshopDuration
+    : eventInfo.value.defaultDiscussionDuration
+  return `${def} min`
 }
 </script>
 
@@ -196,6 +210,17 @@ function authorName(session: SessionItem): string {
                 <v-chip :color="statusColors[session.status]" size="x-small">
                   {{ session.status }}
                 </v-chip>
+                <v-chip
+                  :color="session.type === 'workshop' ? 'orange' : 'blue'"
+                  size="x-small"
+                  variant="tonal"
+                >
+                  {{ session.type }}
+                </v-chip>
+                <span class="d-flex align-center ga-1 text-caption text-grey">
+                  <v-icon size="x-small">mdi-clock-outline</v-icon>
+                  {{ effectiveDuration(session) }}
+                </span>
                 <span class="d-flex align-center ga-1 text-caption text-grey">
                   <v-icon size="x-small" color="amber-darken-2">mdi-star</v-icon>
                   {{ session.starCount }}

--- a/server/database/schema.ts
+++ b/server/database/schema.ts
@@ -25,6 +25,10 @@ export const sessionStatusValues = ['proposed', 'published', 'scheduled', 'deliv
 export type SessionStatus = (typeof sessionStatusValues)[number]
 export const sessionStatusEnum = pgEnum('session_status', sessionStatusValues)
 
+export const sessionTypeValues = ['discussion', 'workshop'] as const
+export type SessionType = (typeof sessionTypeValues)[number]
+export const sessionTypeEnum = pgEnum('session_type', sessionTypeValues)
+
 // ── Events ──────────────────────────────────────────────────────────────────
 export const events = pgTable('events', {
   id: uuid('id').primaryKey().defaultRandom(),
@@ -34,6 +38,8 @@ export const events = pgTable('events', {
   submissionRestricted: boolean('submission_restricted').notNull().default(false),
   minStars: integer('min_stars').notNull().default(4),
   maxStars: integer('max_stars').notNull().default(6),
+  defaultDiscussionDuration: integer('default_discussion_duration').notNull().default(30),
+  defaultWorkshopDuration: integer('default_workshop_duration').notNull().default(75),
   createdAt: timestamp('created_at', { mode: 'date' }).defaultNow().notNull(),
   updatedAt: timestamp('updated_at', { mode: 'date' }).defaultNow().notNull(),
 })
@@ -139,6 +145,8 @@ export const sessions = pgTable('sessions', {
   description: text('description'),
   tags: text('tags').array().notNull().default([]),
   status: sessionStatusEnum('status').notNull().default('proposed'),
+  type: sessionTypeEnum('type').notNull().default('discussion'),
+  duration: integer('duration'),
   createdAt: timestamp('created_at', { mode: 'date' }).defaultNow().notNull(),
   updatedAt: timestamp('updated_at', { mode: 'date' }).defaultNow().notNull(),
 })

--- a/server/routes/api/events/[eventId].put.ts
+++ b/server/routes/api/events/[eventId].put.ts
@@ -14,6 +14,8 @@ export default defineEventHandler(async (event) => {
     submissionRestricted?: boolean
     minStars?: number
     maxStars?: number
+    defaultDiscussionDuration?: number
+    defaultWorkshopDuration?: number
   }>(event)
 
   const updates: Record<string, unknown> = { updatedAt: new Date() }
@@ -33,6 +35,18 @@ export default defineEventHandler(async (event) => {
       throw createError({ statusCode: 400, statusMessage: 'maxStars must be a positive integer' })
     }
     updates.maxStars = body.maxStars
+  }
+  if (body.defaultDiscussionDuration !== undefined) {
+    if (!Number.isInteger(body.defaultDiscussionDuration) || body.defaultDiscussionDuration < 1) {
+      throw createError({ statusCode: 400, statusMessage: 'defaultDiscussionDuration must be a positive integer' })
+    }
+    updates.defaultDiscussionDuration = body.defaultDiscussionDuration
+  }
+  if (body.defaultWorkshopDuration !== undefined) {
+    if (!Number.isInteger(body.defaultWorkshopDuration) || body.defaultWorkshopDuration < 1) {
+      throw createError({ statusCode: 400, statusMessage: 'defaultWorkshopDuration must be a positive integer' })
+    }
+    updates.defaultWorkshopDuration = body.defaultWorkshopDuration
   }
 
   // Validate min <= max using the merged (incoming + existing) values

--- a/server/routes/api/events/[eventId]/sessions/[sessionId].put.ts
+++ b/server/routes/api/events/[eventId]/sessions/[sessionId].put.ts
@@ -1,8 +1,9 @@
 import { eq, and } from 'drizzle-orm'
 import { sessions } from '~/server/database/schema'
-import type { SessionStatus } from '~/server/database/schema'
+import type { SessionStatus, SessionType } from '~/server/database/schema'
 
 const VALID_STATUSES: SessionStatus[] = ['proposed', 'published', 'scheduled', 'delivered']
+const VALID_TYPES: SessionType[] = ['discussion', 'workshop']
 
 const logger = useLogger('sessions')
 
@@ -51,6 +52,18 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 400, statusMessage: 'tags must be an array of strings' })
   }
 
+  if ('type' in body) {
+    if (typeof body.type !== 'string' || !VALID_TYPES.includes(body.type as SessionType)) {
+      throw createError({ statusCode: 400, statusMessage: `type must be one of: ${VALID_TYPES.join(', ')}` })
+    }
+  }
+
+  if ('duration' in body && body.duration !== null) {
+    if (!Number.isInteger(body.duration) || (body.duration as number) < 1) {
+      throw createError({ statusCode: 400, statusMessage: 'duration must be a positive integer (minutes)' })
+    }
+  }
+
   const perms = await getSessionEditPermissions(event, eventId, found)
   if (!perms.canEdit) {
     throw createError({ statusCode: 403, statusMessage: 'Forbidden: you cannot edit this session' })
@@ -60,11 +73,23 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 403, statusMessage: 'Forbidden: participants cannot change session status' })
   }
 
+  // Only staff and admins can set type to "workshop"
+  if ('type' in body && body.type === 'workshop' && !perms.isStaffOrAdmin) {
+    throw createError({ statusCode: 403, statusMessage: 'Forbidden: only admins and staff can set session type to workshop' })
+  }
+
+  // Only admins can set the duration
+  if ('duration' in body && !perms.isAdmin) {
+    throw createError({ statusCode: 403, statusMessage: 'Forbidden: only admins can set session duration' })
+  }
+
   const updates: Record<string, unknown> = { updatedAt: new Date() }
   if ('title' in body) updates.title = (body.title as string).trim()
   if ('description' in body) updates.description = body.description
   if ('tags' in body) updates.tags = body.tags
   if ('status' in body) updates.status = body.status
+  if ('type' in body) updates.type = body.type
+  if ('duration' in body) updates.duration = body.duration
 
   const [updated] = await db
     .update(sessions)

--- a/server/routes/api/events/[eventId]/sessions/index.get.ts
+++ b/server/routes/api/events/[eventId]/sessions/index.get.ts
@@ -27,6 +27,8 @@ async function fetchSessions(
       description: sessions.description,
       tags: sessions.tags,
       status: sessions.status,
+      type: sessions.type,
+      duration: sessions.duration,
       createdAt: sessions.createdAt,
       updatedAt: sessions.updatedAt,
       starCount: sql<number>`(select count(*)::int from session_stars where session_stars.session_id = ${sessions.id})`,

--- a/server/routes/api/events/[eventId]/sessions/index.post.ts
+++ b/server/routes/api/events/[eventId]/sessions/index.post.ts
@@ -1,6 +1,6 @@
 import { eq } from 'drizzle-orm'
 import { events, sessions, users } from '~/server/database/schema'
-import type { SessionStatus } from '~/server/database/schema'
+import type { SessionStatus, SessionType } from '~/server/database/schema'
 
 const logger = useLogger('sessions')
 
@@ -25,6 +25,7 @@ export default defineEventHandler(async (event) => {
     description?: string
     tags?: string[]
     status?: SessionStatus
+    type?: SessionType
   }>(event)
 
   if (!body.title?.trim()) {
@@ -37,6 +38,10 @@ export default defineEventHandler(async (event) => {
 
   if (body.status && !['proposed', 'published', 'scheduled', 'delivered'].includes(body.status)) {
     throw createError({ statusCode: 400, statusMessage: 'Invalid status value' })
+  }
+
+  if (body.type !== undefined && !['discussion', 'workshop'].includes(body.type)) {
+    throw createError({ statusCode: 400, statusMessage: 'type must be "discussion" or "workshop"' })
   }
 
   // Determine author's user ID
@@ -65,6 +70,12 @@ export default defineEventHandler(async (event) => {
     initialStatus = body.status
   }
 
+  // Only staff and admins can create workshop sessions
+  const sessionType: SessionType = body.type ?? 'discussion'
+  if (sessionType === 'workshop' && !isAdminUser && !isStaff) {
+    throw createError({ statusCode: 403, statusMessage: 'Forbidden: only admins and staff can create workshop sessions' })
+  }
+
   const [created] = await db
     .insert(sessions)
     .values({
@@ -74,6 +85,7 @@ export default defineEventHandler(async (event) => {
       description: body.description,
       tags: body.tags ?? [],
       status: initialStatus,
+      type: sessionType,
     })
     .returning()
 

--- a/server/routes/api/events/index.get.ts
+++ b/server/routes/api/events/index.get.ts
@@ -12,6 +12,8 @@ export default defineEventHandler(async (event) => {
     submissionRestricted: events.submissionRestricted,
     minStars: events.minStars,
     maxStars: events.maxStars,
+    defaultDiscussionDuration: events.defaultDiscussionDuration,
+    defaultWorkshopDuration: events.defaultWorkshopDuration,
     createdAt: events.createdAt,
     updatedAt: events.updatedAt,
     inviteeCount: sql<number>`(select count(*)::int from invitees where invitees.event_id = events.id)`,

--- a/server/utils/admin.ts
+++ b/server/utils/admin.ts
@@ -139,22 +139,22 @@ export async function requireSessionSubmission(
  * role is "participant":
  *   – cannot edit once the session status is no longer "proposed"
  *   – cannot change the status field
- * Returns an object with `canEdit` and `canChangeStatus`.
+ * Returns an object with `canEdit`, `canChangeStatus`, `isAdmin`, and `isStaffOrAdmin`.
  */
 export async function getSessionEditPermissions(
   event: H3Event,
   eventId: string,
   sessionRecord: { authorId: string; status: string },
-): Promise<{ canEdit: boolean; canChangeStatus: boolean }> {
+): Promise<{ canEdit: boolean; canChangeStatus: boolean; isAdmin: boolean; isStaffOrAdmin: boolean }> {
   const session = await getUserSession(event)
   const user = session?.user
-  if (!user) return { canEdit: false, canChangeStatus: false }
+  if (!user) return { canEdit: false, canChangeStatus: false, isAdmin: false, isStaffOrAdmin: false }
 
-  const isAdminUser = (user.login && isAdmin(user.login)) || (user.email && isAdminEmail(user.email))
-  if (isAdminUser) return { canEdit: true, canChangeStatus: true }
+  const isAdminUser = !!(user.login && isAdmin(user.login)) || !!(user.email && isAdminEmail(user.email))
+  if (isAdminUser) return { canEdit: true, canChangeStatus: true, isAdmin: true, isStaffOrAdmin: true }
 
   const isStaff = await isStaffForEvent(event, eventId)
-  if (isStaff) return { canEdit: true, canChangeStatus: true }
+  if (isStaff) return { canEdit: true, canChangeStatus: true, isAdmin: false, isStaffOrAdmin: true }
 
   // Look up the current user's DB record to compare with the session's authorId
   const db = useDB()
@@ -165,21 +165,21 @@ export async function getSessionEditPermissions(
     .limit(1)
 
   if (!dbUser || dbUser.id !== sessionRecord.authorId) {
-    return { canEdit: false, canChangeStatus: false }
+    return { canEdit: false, canChangeStatus: false, isAdmin: false, isStaffOrAdmin: false }
   }
 
   // User is the author — check their invitee role for this event
   const role = await getInviteeRoleForEvent(event, eventId)
   if (role === null) {
     // Author is no longer a member of this event — deny editing
-    return { canEdit: false, canChangeStatus: false }
+    return { canEdit: false, canChangeStatus: false, isAdmin: false, isStaffOrAdmin: false }
   }
   if (role === 'participant') {
     const canEdit = sessionRecord.status === 'proposed'
-    return { canEdit, canChangeStatus: false }
+    return { canEdit, canChangeStatus: false, isAdmin: false, isStaffOrAdmin: false }
   }
 
-  // Author with moderator or staff invitee role can fully edit
-  return { canEdit: true, canChangeStatus: true }
+  // Author with moderator invitee role can edit but is not staff/admin
+  return { canEdit: true, canChangeStatus: true, isAdmin: false, isStaffOrAdmin: false }
 }
 

--- a/test/api/events.test.ts
+++ b/test/api/events.test.ts
@@ -233,6 +233,79 @@ describe('Events Endpoints', async () => {
         body: JSON.stringify({ date: '2026-06-15T00:00:00.000Z' }),
       })
     })
+
+    it('seeded event has default discussion and workshop durations', async () => {
+      const res = await fetch(`/api/events/${TEST_EVENT_ID}`, {
+        headers: { Cookie: adminCookies },
+      })
+      expect(res.status).toBe(200)
+      const event = await res.json() as Record<string, unknown>
+      expect(event.defaultDiscussionDuration).toBe(30)
+      expect(event.defaultWorkshopDuration).toBe(75)
+    })
+
+    it('admin can update defaultDiscussionDuration', async () => {
+      const res = await fetch(`/api/events/${TEST_EVENT_ID}`, {
+        method: 'PUT',
+        headers: { Cookie: adminCookies, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ defaultDiscussionDuration: 45 }),
+      })
+      expect(res.status).toBe(200)
+      const event = await res.json() as Record<string, unknown>
+      expect(event.defaultDiscussionDuration).toBe(45)
+
+      // Restore
+      await fetch(`/api/events/${TEST_EVENT_ID}`, {
+        method: 'PUT',
+        headers: { Cookie: adminCookies, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ defaultDiscussionDuration: 30 }),
+      })
+    })
+
+    it('admin can update defaultWorkshopDuration', async () => {
+      const res = await fetch(`/api/events/${TEST_EVENT_ID}`, {
+        method: 'PUT',
+        headers: { Cookie: adminCookies, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ defaultWorkshopDuration: 90 }),
+      })
+      expect(res.status).toBe(200)
+      const event = await res.json() as Record<string, unknown>
+      expect(event.defaultWorkshopDuration).toBe(90)
+
+      // Restore
+      await fetch(`/api/events/${TEST_EVENT_ID}`, {
+        method: 'PUT',
+        headers: { Cookie: adminCookies, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ defaultWorkshopDuration: 75 }),
+      })
+    })
+
+    it('returns 400 for invalid defaultDiscussionDuration (zero)', async () => {
+      const res = await fetch(`/api/events/${TEST_EVENT_ID}`, {
+        method: 'PUT',
+        headers: { Cookie: adminCookies, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ defaultDiscussionDuration: 0 }),
+      })
+      expect(res.status).toBe(400)
+    })
+
+    it('returns 400 for invalid defaultWorkshopDuration (negative)', async () => {
+      const res = await fetch(`/api/events/${TEST_EVENT_ID}`, {
+        method: 'PUT',
+        headers: { Cookie: adminCookies, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ defaultWorkshopDuration: -5 }),
+      })
+      expect(res.status).toBe(400)
+    })
+
+    it('non-admin cannot update default durations', async () => {
+      const res = await fetch(`/api/events/${TEST_EVENT_ID}`, {
+        method: 'PUT',
+        headers: { Cookie: userCookies, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ defaultDiscussionDuration: 60 }),
+      })
+      expect(res.status).toBe(403)
+    })
   })
 
   describe('DELETE /api/events/:id', () => {

--- a/test/api/helpers.ts
+++ b/test/api/helpers.ts
@@ -29,6 +29,7 @@ export async function migrateAndSeed() {
     DROP TABLE IF EXISTS users CASCADE;
     DROP TABLE IF EXISTS events CASCADE;
     DROP TYPE IF EXISTS room_type;
+    DROP TYPE IF EXISTS session_type;
     DROP TYPE IF EXISTS session_status;
     DROP TYPE IF EXISTS invitee_role;
   `)

--- a/test/api/sessions.test.ts
+++ b/test/api/sessions.test.ts
@@ -15,6 +15,7 @@ import {
   TEST_SESSION_SCHEDULED_ID,
   TEST_SESSION_DELIVERED_ID,
   TEST_SESSION_PROPOSED_BY_NOAH_ID,
+  TEST_SESSION_STAFF_PUBLISHED_ID,
 } from './helpers'
 
 const BASE = `/api/events/${TEST_EVENT_ID}/sessions`
@@ -550,6 +551,221 @@ describe('Sessions Endpoints', async () => {
         headers: { Cookie: adminCookies, 'Content-Type': 'application/json' },
         body: JSON.stringify({ submissionRestricted: false }),
       })
+    })
+  })
+
+  // ─── Session type (discussion vs workshop) ───────────────────────────────
+
+  describe('Session type: POST enforcement', () => {
+    it('sessions have a type field in list response', async () => {
+      const res = await fetch(BASE, { headers: { Cookie: adminCookies } })
+      expect(res.status).toBe(200)
+      const list = await res.json() as Array<{ id: string; type: string }>
+      for (const s of list) {
+        expect(['discussion', 'workshop']).toContain(s.type)
+      }
+    })
+
+    it('participant cannot create a workshop session', async () => {
+      const res = await fetch(BASE, {
+        method: 'POST',
+        headers: { Cookie: noahCookies, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title: 'Unauthorized Workshop', type: 'workshop' }),
+      })
+      expect(res.status).toBe(403)
+    })
+
+    it('staff can create a workshop session', async () => {
+      const res = await fetch(BASE, {
+        method: 'POST',
+        headers: { Cookie: staffCookies, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title: 'Staff Workshop', type: 'workshop' }),
+      })
+      expect(res.status).toBe(200)
+      const created = await res.json() as { id: string; type: string }
+      expect(created.type).toBe('workshop')
+
+      // Cleanup
+      await fetch(`${BASE}/${created.id}`, {
+        method: 'DELETE',
+        headers: { Cookie: adminCookies },
+      })
+    })
+
+    it('admin can create a workshop session', async () => {
+      const res = await fetch(BASE, {
+        method: 'POST',
+        headers: { Cookie: adminCookies, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title: 'Admin Workshop', type: 'workshop' }),
+      })
+      expect(res.status).toBe(200)
+      const created = await res.json() as { id: string; type: string }
+      expect(created.type).toBe('workshop')
+
+      // Cleanup
+      await fetch(`${BASE}/${created.id}`, {
+        method: 'DELETE',
+        headers: { Cookie: adminCookies },
+      })
+    })
+
+    it('participant creates a discussion session by default', async () => {
+      const res = await fetch(BASE, {
+        method: 'POST',
+        headers: { Cookie: noahCookies, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title: 'Default Type Session' }),
+      })
+      expect(res.status).toBe(200)
+      const created = await res.json() as { id: string; type: string }
+      expect(created.type).toBe('discussion')
+
+      // Cleanup
+      await fetch(`${BASE}/${created.id}`, {
+        method: 'DELETE',
+        headers: { Cookie: noahCookies },
+      })
+    })
+
+    it('returns 400 for invalid type value', async () => {
+      const res = await fetch(BASE, {
+        method: 'POST',
+        headers: { Cookie: adminCookies, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title: 'Bad Type', type: 'lecture' }),
+      })
+      expect(res.status).toBe(400)
+    })
+  })
+
+  describe('Session type: PUT enforcement', () => {
+    it('participant cannot change type to workshop', async () => {
+      const res = await fetch(`${BASE}/${TEST_SESSION_PROPOSED_BY_NOAH_ID}`, {
+        method: 'PUT',
+        headers: { Cookie: noahCookies, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ type: 'workshop' }),
+      })
+      expect(res.status).toBe(403)
+    })
+
+    it('moderator author cannot change type to workshop', async () => {
+      // Diana is a moderator and author of TEST_SESSION_PROPOSED_BY_DIANA_ID
+      const res = await fetch(`${BASE}/${TEST_SESSION_PROPOSED_BY_DIANA_ID}`, {
+        method: 'PUT',
+        headers: { Cookie: dianaCookies, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ type: 'workshop' }),
+      })
+      expect(res.status).toBe(403)
+    })
+
+    it('admin can change type to workshop', async () => {
+      const res = await fetch(`${BASE}/${TEST_SESSION_PROPOSED_BY_DIANA_ID}`, {
+        method: 'PUT',
+        headers: { Cookie: adminCookies, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ type: 'workshop' }),
+      })
+      expect(res.status).toBe(200)
+      const updated = await res.json() as { type: string }
+      expect(updated.type).toBe('workshop')
+
+      // Restore
+      await fetch(`${BASE}/${TEST_SESSION_PROPOSED_BY_DIANA_ID}`, {
+        method: 'PUT',
+        headers: { Cookie: adminCookies, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ type: 'discussion' }),
+      })
+    })
+
+    it('staff can change type to workshop', async () => {
+      const res = await fetch(`${BASE}/${TEST_SESSION_STAFF_PUBLISHED_ID}`, {
+        method: 'PUT',
+        headers: { Cookie: staffCookies, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ type: 'discussion' }),
+      })
+      expect(res.status).toBe(200)
+      const updated = await res.json() as { type: string }
+      expect(updated.type).toBe('discussion')
+
+      // Restore
+      await fetch(`${BASE}/${TEST_SESSION_STAFF_PUBLISHED_ID}`, {
+        method: 'PUT',
+        headers: { Cookie: adminCookies, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ type: 'workshop' }),
+      })
+    })
+
+    it('returns 400 for invalid type value', async () => {
+      const res = await fetch(`${BASE}/${TEST_SESSION_PROPOSED_BY_DIANA_ID}`, {
+        method: 'PUT',
+        headers: { Cookie: adminCookies, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ type: 'lecture' }),
+      })
+      expect(res.status).toBe(400)
+    })
+  })
+
+  // ─── Session duration ────────────────────────────────────────────────────
+
+  describe('Session duration: PUT enforcement', () => {
+    it('admin can set duration on a session', async () => {
+      const res = await fetch(`${BASE}/${TEST_SESSION_PUBLISHED_ID}`, {
+        method: 'PUT',
+        headers: { Cookie: adminCookies, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ duration: 45 }),
+      })
+      expect(res.status).toBe(200)
+      const updated = await res.json() as { duration: number | null }
+      expect(updated.duration).toBe(45)
+
+      // Restore
+      await fetch(`${BASE}/${TEST_SESSION_PUBLISHED_ID}`, {
+        method: 'PUT',
+        headers: { Cookie: adminCookies, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ duration: null }),
+      })
+    })
+
+    it('admin can clear duration (set to null)', async () => {
+      // First set a duration
+      await fetch(`${BASE}/${TEST_SESSION_PUBLISHED_ID}`, {
+        method: 'PUT',
+        headers: { Cookie: adminCookies, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ duration: 60 }),
+      })
+
+      const res = await fetch(`${BASE}/${TEST_SESSION_PUBLISHED_ID}`, {
+        method: 'PUT',
+        headers: { Cookie: adminCookies, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ duration: null }),
+      })
+      expect(res.status).toBe(200)
+      const updated = await res.json() as { duration: number | null }
+      expect(updated.duration).toBeNull()
+    })
+
+    it('staff cannot set duration', async () => {
+      const res = await fetch(`${BASE}/${TEST_SESSION_STAFF_PUBLISHED_ID}`, {
+        method: 'PUT',
+        headers: { Cookie: staffCookies, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ duration: 90 }),
+      })
+      expect(res.status).toBe(403)
+    })
+
+    it('participant cannot set duration', async () => {
+      const res = await fetch(`${BASE}/${TEST_SESSION_PROPOSED_BY_NOAH_ID}`, {
+        method: 'PUT',
+        headers: { Cookie: noahCookies, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ duration: 30 }),
+      })
+      expect(res.status).toBe(403)
+    })
+
+    it('returns 400 for non-positive duration', async () => {
+      const res = await fetch(`${BASE}/${TEST_SESSION_PUBLISHED_ID}`, {
+        method: 'PUT',
+        headers: { Cookie: adminCookies, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ duration: 0 }),
+      })
+      expect(res.status).toBe(400)
     })
   })
 })

--- a/test/db/events.json
+++ b/test/db/events.json
@@ -5,6 +5,8 @@
     "description": "The best unconference ever",
     "date": "2026-06-15T00:00:00.000Z",
     "minStars": 4,
-    "maxStars": 6
+    "maxStars": 6,
+    "defaultDiscussionDuration": 30,
+    "defaultWorkshopDuration": 75
   }
 ]

--- a/test/db/sessions.json
+++ b/test/db/sessions.json
@@ -51,7 +51,8 @@
     "title": "Staff Session: Workshop Design",
     "description": "Published session authored by staff member Liam.",
     "tags": ["workshop"],
-    "status": "published"
+    "status": "published",
+    "type": "workshop"
   },
   {
     "id": "d0000000-0000-0000-0000-000000000007",


### PR DESCRIPTION
## Why

Unconference sessions now come in two flavors -- discussions (short, conversational) and workshops (longer, hands-on) -- but the app had no way to represent or communicate that distinction to attendees. Admins also had no knob to set how long each format runs by default, and no way to see or override timing per session.

## What changed

### Data model (`server/database/schema.ts`, migration `0006`)
- New `session_type` enum: `discussion` | `workshop`
- `sessions.type` -- `NOT NULL DEFAULT 'discussion'`, so all existing rows are silently migrated
- `sessions.duration` -- nullable integer (minutes); `null` means "use the event default"
- `events.defaultDiscussionDuration` -- `NOT NULL DEFAULT 30`
- `events.defaultWorkshopDuration` -- `NOT NULL DEFAULT 75`

### API enforcement
- `POST /events/:id/sessions` -- only staff/admins may create a `workshop` session
- `PUT /events/:id/sessions/:sid` -- type changes to `workshop` require staff/admin; duration changes require admin
- `PUT /events/:id` -- admins can update both default durations
- `GET /events/:id/sessions` -- `type` and `duration` are included in all responses
- `GET /events` (admin list) -- `defaultDiscussionDuration` and `defaultWorkshopDuration` added to the explicit select

### Admin UI
- Event settings dialog: two new number inputs for default discussion/workshop durations
- Admin sessions table: Type column (teal=discussion, orange=workshop chip) and Duration column (shows override or "N min (default)"); edit dialog gains a type dropdown and clearable duration field

### Participant UI
- `pages/events/[id].vue` and `pages/events/[id]/sessions.vue`: each session card now shows a type chip and effective duration alongside the existing status chip
- Both pages have **Discussion / Workshop filter chips** that compose with existing filters (delivered toggle, starred-only)

### Tests
- 217 API integration tests, all passing
- New test coverage: type/duration fields on session create and update, permission enforcement (workshop restricted to staff+, duration restricted to admin), default duration CRUD on events, DB reset extended to drop the `session_type` enum between test files

## Notes for reviewers
- `session.duration = null` is intentional: it means "inherit the event default". The effective duration is computed client-side as `session.duration ?? event.defaultXxxDuration` based on type.
- The permission gate for `workshop` type uses a new `isStaffOrAdmin` field returned by `getSessionEditPermissions` -- this is important because `canChangeStatus` also returns `true` for moderators, which would have been too broad.