### PR TITLE
Fix schema drift: programmatic migrator and journal timestamp fix

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -134,5 +134,5 @@ npm run db:reset && npm run db:seed   # fresh DB + seed
 npm run dev                            # auto-migrates and starts server
 ```
 
-The `dev` script runs `db:migrate` automatically before starting Nuxt, so any
+The `dev` script runs migrations automatically (via `npx tsx server/database/migrate.ts`) before starting Nuxt, so any
 pending migrations are applied on every `npm run dev`.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -106,3 +106,33 @@ test so later tests are unaffected.
 
 New utility functions under `server/utils/` should have a matching unit test in
 `test/unit/`. Unit tests run in plain Node — no database or Nuxt server needed.
+
+## Data Model Changes
+
+Whenever you change `server/database/schema.ts`, you **must** do all three of the following:
+
+### 1. Generate a migration
+
+```bash
+npx drizzle-kit generate
+```
+
+This creates a new numbered SQL file in `drizzle/`. Give it a descriptive name
+(e.g. `drizzle/0007_add_slots.sql`) — rename the generated file if the default
+name is unclear.
+
+### 2. Update seed data
+
+Update the relevant JSON fixture files in `test/db/` so they include values for
+any new columns. Every column that is `NOT NULL` without a database-level
+default **must** have an explicit value in the seed data.
+
+### 3. Verify locally
+
+```bash
+npm run db:reset && npm run db:seed   # fresh DB + seed
+npm run dev                            # auto-migrates and starts server
+```
+
+The `dev` script runs `db:migrate` automatically before starting Nuxt, so any
+pending migrations are applied on every `npm run dev`.

--- a/docker/initdb/01-migrate.sh
+++ b/docker/initdb/01-migrate.sh
@@ -1,8 +1,35 @@
 #!/bin/bash
 set -e
 
-for f in /drizzle/*.sql; do
-  [ -f "$f" ] || continue
-  echo "Applying migration: $(basename "$f")"
+# Create drizzle tracking schema and migrations table
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<'EOSQL'
+CREATE SCHEMA IF NOT EXISTS drizzle;
+CREATE TABLE IF NOT EXISTS drizzle.__drizzle_migrations (
+  id SERIAL PRIMARY KEY,
+  hash text NOT NULL,
+  created_at bigint
+);
+EOSQL
+
+JOURNAL=/drizzle/meta/_journal.json
+
+# Extract tag|when pairs from journal in order (when comes before tag in each entry)
+extract_entries() {
+  awk '
+    /"when"/ { gsub(/.*"when": */, ""); gsub(/[^0-9].*/, ""); when = $0 }
+    /"tag"/  { gsub(/.*"tag": *"/, ""); gsub(/".*/, ""); tag = $0
+               if (when != "") { print tag "|" when; when = "" } }
+  ' "$JOURNAL"
+}
+
+while IFS='|' read -r tag when; do
+  f="/drizzle/${tag}.sql"
+  [ -f "$f" ] || { echo "WARNING: $f not found, skipping"; continue; }
+
+  echo "Applying migration: ${tag}.sql"
   psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" -f "$f"
-done
+
+  hash=$(sha256sum "$f" | awk '{print $1}')
+  psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" \
+    -c "INSERT INTO drizzle.__drizzle_migrations (hash, created_at) VALUES ('${hash}', ${when})"
+done < <(extract_entries)

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -5,21 +5,21 @@
     {
       "idx": 0,
       "version": "7",
-      "when": 1774270656660,
+      "when": 1740000000000,
       "tag": "0000_watery_ender_wiggin",
       "breakpoints": true
     },
     {
       "idx": 1,
       "version": "7",
-      "when": 1774338672318,
+      "when": 1741000000000,
       "tag": "0001_early_thunderbolt",
       "breakpoints": true
     },
     {
       "idx": 2,
       "version": "7",
-      "when": 1774347473705,
+      "when": 1742000000000,
       "tag": "0002_perpetual_lifeguard",
       "breakpoints": true
     },
@@ -33,14 +33,14 @@
     {
       "idx": 4,
       "version": "7",
-      "when": 1746353179000,
+      "when": 1746349200000,
       "tag": "0004_session_stars",
       "breakpoints": true
     },
     {
       "idx": 5,
       "version": "7",
-      "when": 1746349200000,
+      "when": 1746353179000,
       "tag": "0005_rooms",
       "breakpoints": true
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -11347,7 +11347,6 @@
     },
     "node_modules/playwright/node_modules/fsevents": {
       "version": "2.3.2",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "build": "nuxt build",
-    "dev": "docker compose up -d && npm run db:migrate && nuxt dev",
+    "dev": "docker compose up -d && npx tsx server/database/migrate.ts && nuxt dev",
     "generate": "nuxt generate",
     "preview": "nuxt preview",
     "postinstall": "nuxt prepare",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "build": "nuxt build",
-    "dev": "docker compose up -d && nuxt dev",
+    "dev": "docker compose up -d && npm run db:migrate && nuxt dev",
     "generate": "nuxt generate",
     "preview": "nuxt preview",
     "postinstall": "nuxt prepare",

--- a/server/database/migrate.ts
+++ b/server/database/migrate.ts
@@ -1,0 +1,51 @@
+import { drizzle } from 'drizzle-orm/postgres-js'
+import { migrate } from 'drizzle-orm/postgres-js/migrator'
+import postgres from 'postgres'
+import { resolve, dirname } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { readFileSync } from 'node:fs'
+import { createHash } from 'node:crypto'
+import { createConsola } from 'consola'
+
+const logger = createConsola().withTag('migrate')
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const migrationsFolder = resolve(__dirname, '../../drizzle')
+
+const client = postgres(process.env.DATABASE_URL!)
+const db = drizzle(client)
+
+// Backfill drizzle.__drizzle_migrations when tables already exist but tracking
+// is empty (e.g. DB was initialized via Docker init scripts without tracking).
+async function backfillMigrationHistory() {
+  const journal = JSON.parse(readFileSync(resolve(migrationsFolder, 'meta/_journal.json'), 'utf-8'))
+  for (const entry of journal.entries) {
+    const content = readFileSync(resolve(migrationsFolder, `${entry.tag}.sql`), 'utf-8')
+    const hash = createHash('sha256').update(content).digest('hex')
+    await client`INSERT INTO drizzle.__drizzle_migrations (hash, created_at) VALUES (${hash}, ${entry.when})`
+  }
+}
+
+async function runMigrations() {
+  logger.info('Running migrations...')
+  try {
+    await migrate(db, { migrationsFolder })
+  } catch (err: unknown) {
+    const cause = (err as { cause?: { message?: string } })?.cause
+    if (cause?.message?.includes('already exists')) {
+      logger.warn('Tables exist without migration tracking — backfilling migration history')
+      await backfillMigrationHistory()
+      await migrate(db, { migrationsFolder })
+    } else {
+      throw err
+    }
+  }
+  logger.success('Migrations complete!')
+  await client.end()
+}
+
+runMigrations().catch((err) => {
+  logger.error('Migration failed:', err)
+  process.exit(1)
+})
+


### PR DESCRIPTION
The app was failing on startup with `column "default_discussion_duration" does not exist` because migration `0006_session_type_duration` was never applied to the dev database. Three root causes compounded each other, all fixed here.

## What was broken

1. **`_journal.json` had wrong timestamps** -- migrations 0000-0002 had 2026 timestamps (typo), making drizzle skip any 2025-dated migration, including 0006.
2. **Docker init script didn't track migrations** -- `01-migrate.sh` applied SQL files directly without populating `drizzle.__drizzle_migrations`, so the tracking table was always empty on fresh containers.
3. **`drizzle-kit migrate` hangs without a TTY** -- the CLI uses a spinner and blocks when chained with `&&` in the dev script.

## What changed

- **`server/database/migrate.ts`** (new): programmatic migrator using drizzle's Node API. Exits cleanly in non-TTY contexts. Also detects the "tables exist but tracking table is empty" state (from Docker-initialized DBs) and backfills migration history automatically before retrying.
- **`docker/initdb/01-migrate.sh`**: now creates the `drizzle` schema/table and records each migration's SHA-256 hash and timestamp (read from `_journal.json`) so fresh containers are fully in sync with drizzle's migration state.
- **`drizzle/meta/_journal.json`**: corrected timestamps for migrations 0000-0002 to be chronologically before the 2025 migrations, restoring a monotonically increasing sequence.
- **`package.json`**: dev script now runs `npx tsx server/database/migrate.ts` instead of `drizzle-kit migrate`.
- **`.github/copilot-instructions.md`**: added a "Data Model Changes" section requiring that every `schema.ts` change is accompanied by a new drizzle migration and updated `test/db/*.json` seed fixtures.