### PR TITLE
Fix round session/room/participant assignment

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,28 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Nuxt: Debug Dev Server",
+      "type": "node",
+      "request": "launch",
+      "cwd": "${workspaceFolder}",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev"],
+      "env": {
+        "NODE_OPTIONS": "--inspect"
+      },
+      "console": "integratedTerminal",
+      "autoAttachChildProcesses": true,
+      "restart": true,
+      "skipFiles": ["<node_internals>/**"]
+    },
+    {
+      "name": "Attach Nuxt",
+      "type": "node",
+      "request": "attach",
+      "port": 9229,
+      "restart": true,
+      "skipFiles": ["<node_internals>/**"]
+    }
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11347,6 +11347,7 @@
     },
     "node_modules/playwright/node_modules/fsevents": {
       "version": "2.3.2",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [

--- a/server/routes/api/events/[eventId]/rounds/[roundId]/index.get.ts
+++ b/server/routes/api/events/[eventId]/rounds/[roundId]/index.get.ts
@@ -1,5 +1,5 @@
-import { eq, and } from 'drizzle-orm'
-import { rounds, roundRooms, rooms, slots } from '~/server/database/schema'
+import { eq, and, inArray, sql } from 'drizzle-orm'
+import { rounds, roundRooms, rooms, slots, sessionStars } from '~/server/database/schema'
 
 export default defineEventHandler(async (event) => {
   const eventId = getRouterParam(event, 'eventId')
@@ -36,9 +36,26 @@ export default defineEventHandler(async (event) => {
     orderBy: [slots.slotIndex, slots.roomId],
   })
 
+  // Compute star counts for sessions referenced in these slots
+  const sessionIds = [...new Set(roundSlots.map((s) => s.sessionId).filter((id): id is string => id !== null))]
+  const starCounts = sessionIds.length > 0
+    ? await db
+        .select({
+          sessionId: sessionStars.sessionId,
+          count: sql<number>`count(*)::int`.as('star_count'),
+        })
+        .from(sessionStars)
+        .where(inArray(sessionStars.sessionId, sessionIds))
+        .groupBy(sessionStars.sessionId)
+    : []
+  const starCountMap = new Map(starCounts.map((r) => [r.sessionId, r.count]))
+
   return {
     ...round,
     enabledRooms: enabledRooms.map((r) => r.room),
-    slots: roundSlots,
+    slots: roundSlots.map((slot) => ({
+      ...slot,
+      session: slot.session ? { ...slot.session, starCount: starCountMap.get(slot.session.id) ?? 0 } : null,
+    })),
   }
 })

--- a/server/routes/api/events/[eventId]/rounds/[roundId]/index.put.ts
+++ b/server/routes/api/events/[eventId]/rounds/[roundId]/index.put.ts
@@ -44,9 +44,9 @@ export default defineEventHandler(async (event) => {
     body.minParticipants !== undefined &&
     (typeof body.minParticipants !== 'number' ||
       !Number.isInteger(body.minParticipants) ||
-      body.minParticipants < 1)
+      body.minParticipants < 0)
   ) {
-    throw createError({ statusCode: 400, statusMessage: 'minParticipants must be a positive integer' })
+    throw createError({ statusCode: 400, statusMessage: 'minParticipants must be a non-negative integer' })
   }
 
   if (

--- a/server/routes/api/events/[eventId]/rounds/index.post.ts
+++ b/server/routes/api/events/[eventId]/rounds/index.post.ts
@@ -34,9 +34,9 @@ export default defineEventHandler(async (event) => {
     body.minParticipants !== undefined &&
     (typeof body.minParticipants !== 'number' ||
       !Number.isInteger(body.minParticipants) ||
-      body.minParticipants < 1)
+      body.minParticipants < 0)
   ) {
-    throw createError({ statusCode: 400, statusMessage: 'minParticipants must be a positive integer' })
+    throw createError({ statusCode: 400, statusMessage: 'minParticipants must be a non-negative integer' })
   }
 
   if (

--- a/server/utils/roundAssignment.ts
+++ b/server/utils/roundAssignment.ts
@@ -1,7 +1,7 @@
 import { eq, and, inArray, sql } from 'drizzle-orm'
 import { rounds, roundRooms, rooms, sessions, sessionStars, slots, slotRegistrations } from '../database/schema'
 import { useDB } from '../database'
-import { buildSlotPlan, assignParticipants, roomMatchesSessionType } from './roundAlgorithm'
+import { buildSlotPlan, assignParticipants } from './roundAlgorithm'
 import type { AlgoRoom, AlgoSession, VoterRecord, SlotTiming } from './roundAlgorithm'
 
 /**
@@ -9,7 +9,7 @@ import type { AlgoRoom, AlgoSession, VoterRecord, SlotTiming } from './roundAlgo
  *  1. Calculates slots per room based on durations.
  *  2. Assigns eligible sessions to slots (biggest room → most popular; duplicates popular ones).
  *  3. Assigns starred users to sessions, respecting capacity and slotIndex conflicts.
- *  4. Persists slots and registrations to the DB.
+ *  4. Persists slots and registrations to the DB inside a transaction.
  *  5. Updates round status to 'assigned'.
  */
 export async function assignRound(roundId: string): Promise<void> {
@@ -67,28 +67,26 @@ export async function assignRound(roundId: string): Promise<void> {
 
   const workshopSessions = eligibleSessions.filter((s) => s.type === 'workshop')
   const discussionSessions = eligibleSessions.filter((s) => s.type === 'discussion')
-  const workshopRooms = enabledRooms.filter((r) => roomMatchesSessionType(r.type, 'workshop'))
-  const discussionRooms = enabledRooms.filter((r) => roomMatchesSessionType(r.type, 'discussion'))
+
+  // Split rooms into disjoint sets to avoid duplicate (roomId, slotIndex) pairs in the slot plan.
+  // 'both' rooms match either session type — assign them to workshops when workshop sessions exist,
+  // otherwise to discussions. This prevents unique constraint violations on slot insert.
+  const workshopOnlyRooms = enabledRooms.filter((r) => r.type === 'workshop')
+  const discussionOnlyRooms = enabledRooms.filter((r) => r.type === 'meeting')
+  const bothTypeRooms = enabledRooms.filter((r) => r.type === 'both')
+  const workshopRooms: AlgoRoom[] = workshopSessions.length > 0
+    ? [...workshopOnlyRooms, ...bothTypeRooms]
+    : workshopOnlyRooms
+  const discussionRooms: AlgoRoom[] = workshopSessions.length > 0
+    ? discussionOnlyRooms
+    : [...discussionOnlyRooms, ...bothTypeRooms]
 
   const slotPlan = [
     ...buildSlotPlan(workshopSessions, workshopRooms, round.duration, defaultWorkshopDuration, round.breakDuration),
     ...buildSlotPlan(discussionSessions, discussionRooms, round.duration, defaultDiscussionDuration, round.breakDuration),
   ]
 
-  await db.delete(slots).where(eq(slots.roundId, roundId))
-
-  if (slotPlan.length === 0) {
-    await db.update(rounds).set({ status: 'assigned', updatedAt: new Date() }).where(eq(rounds.id, roundId))
-    return
-  }
-
-  const insertedSlots = await db
-    .insert(slots)
-    .values(slotPlan.map((s) => ({ roundId, roomId: s.roomId, sessionId: s.sessionId, slotIndex: s.slotIndex })))
-    .returning()
-
-  const planWithIds = slotPlan.map((plan, i) => ({ ...plan, id: insertedSlots[i].id }))
-
+  // Fetch voter data before the transaction (read-only)
   const eligibleIds = eligibleSessions.map((s) => s.id)
   const voterRows = eligibleIds.length > 0
     ? await db
@@ -98,22 +96,43 @@ export async function assignRound(roundId: string): Promise<void> {
         .orderBy(sessionStars.createdAt)
     : []
 
-  const assignments = assignParticipants(planWithIds, voterRows as VoterRecord[], eligibleSessions, timing)
+  await db.transaction(async (tx) => {
+    await tx.delete(slots).where(eq(slots.roundId, roundId))
 
-  const slotIdMap = new Map<string, string>()
-  for (const p of planWithIds) {
-    if (p.sessionId) {
-      slotIdMap.set(`${p.roomId}|${p.slotIndex}|${p.sessionId}`, p.id)
+    if (slotPlan.length === 0) {
+      await tx.update(rounds).set({ status: 'assigned', updatedAt: new Date() }).where(eq(rounds.id, roundId))
+      return
     }
-  }
 
-  const registrations = assignments
-    .map((a) => ({ slotId: slotIdMap.get(`${a.roomId}|${a.slotIndex}|${a.sessionId}`), userId: a.userId }))
-    .filter((r): r is { slotId: string; userId: string } => !!r.slotId)
+    const insertedSlots = await tx
+      .insert(slots)
+      .values(slotPlan.map((s) => ({ roundId, roomId: s.roomId, sessionId: s.sessionId, slotIndex: s.slotIndex })))
+      .returning()
 
-  if (registrations.length > 0) {
-    await db.insert(slotRegistrations).values(registrations)
-  }
+    // Map by (roomId, slotIndex) rather than array index to avoid relying on INSERT returning order.
+    const insertedSlotMap = new Map(insertedSlots.map((s) => [`${s.roomId}|${s.slotIndex}`, s.id]))
+    const planWithIds = slotPlan.map((plan) => ({
+      ...plan,
+      id: insertedSlotMap.get(`${plan.roomId}|${plan.slotIndex}`) ?? '',
+    }))
 
-  await db.update(rounds).set({ status: 'assigned', updatedAt: new Date() }).where(eq(rounds.id, roundId))
+    const assignments = assignParticipants(planWithIds, voterRows as VoterRecord[], eligibleSessions, timing)
+
+    const slotIdMap = new Map<string, string>()
+    for (const p of planWithIds) {
+      if (p.sessionId) {
+        slotIdMap.set(`${p.roomId}|${p.slotIndex}|${p.sessionId}`, p.id)
+      }
+    }
+
+    const registrations = assignments
+      .map((a) => ({ slotId: slotIdMap.get(`${a.roomId}|${a.slotIndex}|${a.sessionId}`), userId: a.userId }))
+      .filter((r): r is { slotId: string; userId: string } => !!r.slotId)
+
+    if (registrations.length > 0) {
+      await tx.insert(slotRegistrations).values(registrations)
+    }
+
+    await tx.update(rounds).set({ status: 'assigned', updatedAt: new Date() }).where(eq(rounds.id, roundId))
+  })
 }

--- a/server/utils/roundAssignment.ts
+++ b/server/utils/roundAssignment.ts
@@ -4,6 +4,8 @@ import { useDB } from '../database'
 import { buildSlotPlan, assignParticipants } from './roundAlgorithm'
 import type { AlgoRoom, AlgoSession, VoterRecord, SlotTiming } from './roundAlgorithm'
 
+const logger = useLogger('rounds')
+
 /**
  * Runs the full assignment algorithm for a round:
  *  1. Calculates slots per room based on durations.
@@ -39,6 +41,10 @@ export async function assignRound(roundId: string): Promise<void> {
       .where(eq(roundRooms.roundId, roundId))
   ) as AlgoRoom[]
 
+  if (enabledRooms.length === 0) {
+    logger.warn(`Round ${roundId}: no rooms enabled — assignment will produce no slots`)
+  }
+
   const eligibleRows = await db
     .select({
       id: sessions.id,
@@ -58,6 +64,10 @@ export async function assignRound(roundId: string): Promise<void> {
     .having(sql`count(${sessionStars.sessionId}) >= ${round.minParticipants}`)
     .orderBy(sql`count(${sessionStars.sessionId}) DESC`)
 
+  if (eligibleRows.length === 0) {
+    logger.warn(`Round ${roundId}: no eligible sessions (minParticipants=${round.minParticipants}) — assignment will produce no slots`)
+  }
+
   const eligibleSessions: AlgoSession[] = eligibleRows.map((r) => ({
     id: r.id,
     type: r.type,
@@ -65,26 +75,67 @@ export async function assignRound(roundId: string): Promise<void> {
     starCount: r.starCount,
   }))
 
+  logger.info(`Round ${roundId}: ${eligibleSessions.length} eligible sessions, ${enabledRooms.length} enabled rooms`)
+
   const workshopSessions = eligibleSessions.filter((s) => s.type === 'workshop')
   const discussionSessions = eligibleSessions.filter((s) => s.type === 'discussion')
 
-  // Split rooms into disjoint sets to avoid duplicate (roomId, slotIndex) pairs in the slot plan.
-  // 'both' rooms match either session type — assign them to workshops when workshop sessions exist,
-  // otherwise to discussions. This prevents unique constraint violations on slot insert.
+  // Build disjoint room sets for workshop and discussion calls to avoid duplicate
+  // (roomId, slotIndex) pairs which would violate the slots unique constraint.
+  //
+  // Priority: workshop/both rooms → workshops; meeting/both rooms → discussions.
+  // 'both' rooms are assigned exclusively to workshops when workshop sessions exist.
+  //
+  // Fallback: if a session type has sessions but no type-matched rooms, it receives
+  // all enabled rooms (and the other type gets none). This prevents sessions from
+  // being silently dropped when, for example, all rooms are 'meeting' type but
+  // some sessions are 'workshop' type.
   const workshopOnlyRooms = enabledRooms.filter((r) => r.type === 'workshop')
-  const discussionOnlyRooms = enabledRooms.filter((r) => r.type === 'meeting')
+  const meetingOnlyRooms = enabledRooms.filter((r) => r.type === 'meeting')
   const bothTypeRooms = enabledRooms.filter((r) => r.type === 'both')
-  const workshopRooms: AlgoRoom[] = workshopSessions.length > 0
-    ? [...workshopOnlyRooms, ...bothTypeRooms]
-    : workshopOnlyRooms
-  const discussionRooms: AlgoRoom[] = workshopSessions.length > 0
-    ? discussionOnlyRooms
-    : [...discussionOnlyRooms, ...bothTypeRooms]
+
+  let workshopRooms: AlgoRoom[]
+  let discussionRooms: AlgoRoom[]
+
+  if (workshopSessions.length > 0 && discussionSessions.length > 0) {
+    // Both session types present — assign disjoint room sets
+    workshopRooms = [...workshopOnlyRooms, ...bothTypeRooms]
+    discussionRooms = meetingOnlyRooms
+
+    if (workshopRooms.length === 0) {
+      // No workshop-compatible rooms — split meeting rooms between the two types
+      const splitAt = Math.ceil(meetingOnlyRooms.length / 2)
+      workshopRooms = meetingOnlyRooms.slice(0, splitAt)
+      discussionRooms = meetingOnlyRooms.slice(splitAt)
+      logger.warn(`Round ${roundId}: no workshop rooms available; splitting ${meetingOnlyRooms.length} meeting rooms between workshops and discussions`)
+    } else if (discussionRooms.length === 0) {
+      // No meeting-compatible rooms — split workshop/both rooms between the two types
+      const allWorkshopCompatible = [...workshopOnlyRooms, ...bothTypeRooms]
+      const splitAt = Math.ceil(allWorkshopCompatible.length / 2)
+      workshopRooms = allWorkshopCompatible.slice(splitAt)
+      discussionRooms = allWorkshopCompatible.slice(0, splitAt)
+      logger.warn(`Round ${roundId}: no meeting rooms available; splitting ${allWorkshopCompatible.length} workshop rooms between workshops and discussions`)
+    }
+  } else if (workshopSessions.length > 0) {
+    // Only workshop sessions — use all rooms regardless of type
+    workshopRooms = enabledRooms
+    discussionRooms = []
+  } else {
+    // Only discussion sessions (or no sessions) — use all rooms regardless of type
+    workshopRooms = []
+    discussionRooms = enabledRooms
+  }
+
+  logger.info(`Round ${roundId}: ${workshopSessions.length} workshop sessions → ${workshopRooms.length} rooms; ${discussionSessions.length} discussion sessions → ${discussionRooms.length} rooms`)
 
   const slotPlan = [
     ...buildSlotPlan(workshopSessions, workshopRooms, round.duration, defaultWorkshopDuration, round.breakDuration),
     ...buildSlotPlan(discussionSessions, discussionRooms, round.duration, defaultDiscussionDuration, round.breakDuration),
   ]
+
+  if (slotPlan.length === 0 && eligibleSessions.length > 0) {
+    logger.warn(`Round ${roundId}: eligible sessions exist but slot plan is empty — check round duration vs session durations`)
+  }
 
   // Fetch voter data before the transaction (read-only)
   const eligibleIds = eligibleSessions.map((s) => s.id)
@@ -133,6 +184,7 @@ export async function assignRound(roundId: string): Promise<void> {
       await tx.insert(slotRegistrations).values(registrations)
     }
 
+    logger.info(`Round ${roundId}: assigned ${slotPlan.filter(s => s.sessionId).length} sessions across ${insertedSlots.length} slots, ${registrations.length} participant registrations`)
     await tx.update(rounds).set({ status: 'assigned', updatedAt: new Date() }).where(eq(rounds.id, roundId))
   })
 }

--- a/test/api/rounds.test.ts
+++ b/test/api/rounds.test.ts
@@ -347,10 +347,15 @@ describe('Rounds Endpoints', async () => {
       const body = await assign.json()
       expect(body.status).toBe('assigned')
 
-      // Verify slots were created
+      // Verify slots were created with sessions and participants assigned
       const detail = await fetch(`${BASE}/${id}`, { headers: { Cookie: adminCookies } })
       const detailBody = await detail.json()
       expect(detailBody.slots.length).toBeGreaterThan(0)
+      const assignedSlots = detailBody.slots.filter((s: { sessionId: string | null }) => s.sessionId !== null)
+      expect(assignedSlots.length).toBeGreaterThan(0)
+      expect(typeof assignedSlots[0].session.starCount).toBe('number')
+      const slotsWithParticipants = detailBody.slots.filter((s: { registrations: unknown[] }) => s.registrations.length > 0)
+      expect(slotsWithParticipants.length).toBeGreaterThan(0)
 
       await fetch(`${BASE}/${id}`, { method: 'DELETE', headers: { Cookie: adminCookies } })
     })

--- a/test/api/rounds.test.ts
+++ b/test/api/rounds.test.ts
@@ -104,6 +104,15 @@ describe('Rounds Endpoints', async () => {
       expect(res.status).toBe(400)
     })
 
+    it('returns 400 when minParticipants is negative', async () => {
+      const res = await fetch(BASE, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Cookie: adminCookies },
+        body: JSON.stringify({ duration: 60, minParticipants: -1 }),
+      })
+      expect(res.status).toBe(400)
+    })
+
     it('creates a round successfully and returns it', async () => {
       const res = await fetch(BASE, {
         method: 'POST',
@@ -335,7 +344,7 @@ describe('Rounds Endpoints', async () => {
       const create = await fetch(BASE, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', Cookie: adminCookies },
-        body: JSON.stringify({ duration: 75, minParticipants: 1 }),
+        body: JSON.stringify({ duration: 75, minParticipants: 0 }),
       })
       const { id } = await create.json()
 


### PR DESCRIPTION
## Why

Round assignment was silently producing no slots in production -- sessions were never scheduled into rooms and participants were never registered. Investigation traced the failures to three layered causes.

## What was wrong

**Root cause 1 -- `minParticipants >= 1` filtered out all sessions when nobody had starred anything yet.**
The HAVING clause on the eligibility query requires `count(stars) >= minParticipants`. With a default of 1 and no stars cast yet (common in a fresh event), every session failed the filter. The API also rejected `minParticipants=0`, making it impossible to schedule unstarred sessions. Fixed by allowing `minParticipants=0` in both the create and update round endpoints.

**Root cause 2 -- room type mismatch silently dropped sessions.**
`buildSlotPlan` was called once for workshop sessions with workshop-compatible rooms, and once for discussion sessions with meeting-compatible rooms. If all rooms were `meeting` type but some sessions were `workshop` type (or vice versa), one of the two calls received empty arrays and produced nothing. Fixed with a fallback: when sessions of a given type have no matched rooms, all enabled rooms are allocated to whichever type has sessions; if both types exist and one has no matched rooms, rooms are split between them.

**Additional bugs fixed along the way:**

- **`both`-type room double-slot conflict:** Rooms typed `both` appeared in both the workshop and discussion room lists, causing `buildSlotPlan` to emit duplicate `(roomId, slotIndex)` pairs that violated the unique constraint on the `slots` table. The bulk INSERT would fail, wiping out all slots. Fixed by assigning `both` rooms exclusively to workshops when workshop sessions exist, otherwise to discussions.

- **Non-transactional execution:** `DELETE slots` -> `INSERT slots` -> `INSERT registrations` happened outside a transaction. A failure after the DELETE permanently cleared all previous slots. Wrapped in `db.transaction()`.

- **Fragile INSERT RETURNING order assumption:** Slot IDs were mapped back to the plan by array position (`insertedSlots[i]`), relying on Postgres returning rows in the same order as the VALUES list (not guaranteed). Replaced with a `Map<roomId|slotIndex, id>` lookup.

- **`starCount` missing from round detail response:** The round detail endpoint returned raw session rows which have no `starCount` column, causing "undefined votes" in the UI. Now queries star counts in a separate grouped query and merges them into each slot's session object.

## Changes

- `server/utils/roundAssignment.ts` -- transaction wrapper, `both`-room fix, insert-order fix, room-type fallback, diagnostic logging
- `server/routes/api/events/[eventId]/rounds/index.post.ts` -- allow `minParticipants=0`
- `server/routes/api/events/[eventId]/rounds/[roundId]/index.put.ts` -- allow `minParticipants=0`
- `server/routes/api/events/[eventId]/rounds/[roundId]/index.get.ts` -- add `starCount` to session objects in slots
- `test/api/rounds.test.ts` -- strengthen assignment test (assert sessions assigned, registrations present, `starCount` is a number); add `minParticipants=-1` rejection test