### PR TITLE
fix: seed all missing tables from test/db fixtures

### DIFF
--- a/server/database/seed.ts
+++ b/server/database/seed.ts
@@ -44,7 +44,34 @@ async function seed() {
 
   await db.insert(schema.sessions).values(loadJson('sessions.json'))
 
+  await db.insert(schema.sessionStars).values(loadJson('session-stars.json'))
+
   await db.insert(schema.rooms).values(loadJson('rooms.json'))
+
+  const roundsData = loadJson('rounds.json')
+  if (roundsData.length > 0) {
+    await db.insert(schema.rounds).values(
+      roundsData.map((r: Record<string, unknown>) => ({
+        ...r,
+        ...(r.startTime ? { startTime: new Date(r.startTime as string) } : {}),
+      })),
+    )
+
+    const roundRoomsData = loadJson('round-rooms.json')
+    if (roundRoomsData.length > 0) {
+      await db.insert(schema.roundRooms).values(roundRoomsData)
+    }
+
+    const slotsData = loadJson('slots.json')
+    if (slotsData.length > 0) {
+      await db.insert(schema.slots).values(slotsData)
+
+      const slotRegistrationsData = loadJson('slot-registrations.json')
+      if (slotRegistrationsData.length > 0) {
+        await db.insert(schema.slotRegistrations).values(slotRegistrationsData)
+      }
+    }
+  }
 
   logger.success('Seeding complete!')
   await client.end()


### PR DESCRIPTION
The `seed.ts` script was only loading 7 of the 12 fixture files in `test/db/`, leaving `sessionStars`, `rounds`, `roundRooms`, `slots`, and `slotRegistrations` unpopulated when running `npm run db:seed` or `npm run db:reset`.

This meant the local dev database was missing star/voting data, scheduling rounds, room assignments, session slots, and attendee registrations -- making the app behave differently from the test environment where `migrateAndSeed()` in `test/api/helpers.ts` already handled all tables correctly.

**Changes:**
- Insert `session-stars.json` into `sessionStars` after `sessions` (FK order)
- Insert `rounds.json` into `rounds` with `startTime` date coercion (matching helpers.ts)
- Insert `round-rooms.json`, `slots.json`, and `slot-registrations.json` in FK-safe nested order
- All three scheduling-related inserts are guarded with `length > 0` checks so empty fixtures are a no-op