### PR TITLE
Add rounds link to event actions on admin dashboard

### DIFF
--- a/pages/admin/events/index.vue
+++ b/pages/admin/events/index.vue
@@ -213,6 +213,16 @@ async function confirmDelete() {
           <v-icon>mdi-door</v-icon>
           <v-tooltip activator="parent" location="top">Manage Rooms</v-tooltip>
         </v-btn>
+        <v-btn
+          icon
+          size="small"
+          variant="text"
+          color="orange-darken-2"
+          :to="`/admin/events/${item.id}/rounds`"
+        >
+          <v-icon>mdi-timer-play-outline</v-icon>
+          <v-tooltip activator="parent" location="top">Manage Rounds</v-tooltip>
+        </v-btn>
         <v-btn icon size="small" variant="text" color="error" @click="openDelete(item)">
           <v-icon>mdi-delete</v-icon>
           <v-tooltip activator="parent" location="top">Delete</v-tooltip>


### PR DESCRIPTION
The admin events table had action buttons for invitees, sessions, and rooms, but no shortcut to manage rounds. Admins had to navigate manually to reach the rounds page.

Adds a "Manage Rounds" icon button (orange timer icon, `mdi-timer-play-outline`) to each event row's action column in `pages/admin/events/index.vue`, linking to `/admin/events/{id}/rounds`. It sits between the Rooms and Delete buttons, consistent with the existing button style and pattern.