### PR TITLE
Add Rounds link to dashboard admin event cards

### DIFF
--- a/pages/dashboard.vue
+++ b/pages/dashboard.vue
@@ -134,6 +134,15 @@ watch(
                 <v-btn
                   size="small"
                   variant="text"
+                  color="orange-darken-2"
+                  :to="`/admin/events/${ev.id}/rounds`"
+                  prepend-icon="mdi-timer-play-outline"
+                >
+                  Rounds
+                </v-btn>
+                <v-btn
+                  size="small"
+                  variant="text"
                   color="primary"
                   to="/admin/events"
                   prepend-icon="mdi-pencil"


### PR DESCRIPTION
The admin/events page already had a "Manage Rounds" button for each event, but the dashboard's admin view was missing the same shortcut, requiring an extra navigation step.

This adds a Rounds button to each event card in the dashboard's admin view, matching the existing style (orange, `mdi-timer-play-outline` icon, links to `/admin/events/{id}/rounds`) used on the admin/events page.