### PR TITLE
Make AUTH_MODE configurable in the Azure infra workflow

### DIFF
--- a/.github/workflows/azure-infra.yml
+++ b/.github/workflows/azure-infra.yml
@@ -22,6 +22,14 @@ on:
         description: 'Container Apps Environment name'
         required: true
         default: 'cae-unconference'
+      auth_mode:
+        description: 'Authentication mode (github or local)'
+        required: true
+        default: 'github'
+        type: choice
+        options:
+          - github
+          - local
 
 permissions:
   id-token: write
@@ -36,6 +44,7 @@ jobs:
       LOCATION: ${{ github.event.inputs.location }}
       ACR_NAME: ${{ github.event.inputs.acr_name }}
       CAE_NAME: ${{ github.event.inputs.environment_name }}
+      AUTH_MODE: ${{ github.event.inputs.auth_mode }}
       APP_NAME: unconference-app
       DB_APP_NAME: unconference-db
       IDENTITY_NAME: id-unconference
@@ -222,13 +231,21 @@ jobs:
                 "NUXT_SESSION_PASSWORD=secretref:session-password" \
                 "NUXT_OAUTH_GITHUB_CLIENT_ID=secretref:github-client-id" \
                 "NUXT_OAUTH_GITHUB_CLIENT_SECRET=secretref:github-client-secret" \
-                "AUTH_MODE=github" \
+                "AUTH_MODE=${AUTH_MODE}" \
                 "NODE_ENV=production" \
               --output none
             echo "✅ Nuxt container app created: $APP_NAME"
           else
             echo "ℹ️  Nuxt container app already exists: $APP_NAME"
           fi
+
+          # Always sync AUTH_MODE so re-running the workflow applies changes to existing apps
+          az containerapp update \
+            --name "$APP_NAME" \
+            --resource-group "$RESOURCE_GROUP" \
+            --set-env-vars "AUTH_MODE=${AUTH_MODE}" \
+            --output none
+          echo "✅ AUTH_MODE set to '${AUTH_MODE}' on $APP_NAME"
 
       # ── Summary ────────────────────────────────────────────────────────────
       - name: Print Application URL


### PR DESCRIPTION
Previously `AUTH_MODE` was hardcoded to `github` in the Azure Container Apps provisioning workflow, making it impossible to run the app in local-auth mode in a production deployment without manually editing the workflow or patching the container app through the portal.

## What changed

- Added an `auth_mode` workflow dispatch input (dropdown: `github` | `local`, default `github`) so the desired auth mode can be chosen at run time.
- Wired the input through a job-level `AUTH_MODE` env var and replaced the hardcoded value in the container creation `--env-vars` block.
- Added an `az containerapp update --set-env-vars` call that runs unconditionally after the create-or-skip block, so re-running the workflow on an already-provisioned app also applies the selected mode immediately -- no manual portal intervention needed.