### PR TITLE
feat: make seed script available in production image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,12 @@ RUN node_modules/.bin/esbuild server/database/migrate.ts \
     --external:postgres --external:drizzle-orm \
     --outfile=server/database/migrate.mjs
 
+# Bundle the seed script the same way.
+RUN node_modules/.bin/esbuild server/database/seed.ts \
+    --bundle --platform=node --format=esm \
+    --external:postgres --external:drizzle-orm \
+    --outfile=server/database/seed.mjs
+
 # ── Production stage ───────────────────────────────────────────────────────────
 FROM node:22-slim AS runner
 WORKDIR /app
@@ -31,7 +37,9 @@ COPY --from=builder /app/.output ./.output
 # Migration script (placed at the same relative depth as the source so the
 # bundled __dirname-based path ../../drizzle resolves to /app/drizzle).
 COPY --from=builder /app/server/database/migrate.mjs ./server/database/migrate.mjs
+COPY --from=builder /app/server/database/seed.mjs ./server/database/seed.mjs
 COPY drizzle ./drizzle
+COPY test/db ./test/db
 
 EXPOSE 3000
 ENV PORT=3000

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test": "vitest",
     "db:migrate": "drizzle-kit migrate",
     "db:seed": "npx tsx server/database/seed.ts",
+    "db:seed:prod": "node /app/server/database/seed.mjs",
     "db:reset": "docker compose down -v && docker compose up -d && sleep 3",
     "test:watch": "vitest --watch",
     "test:unit": "vitest --project unit",


### PR DESCRIPTION
The production Docker image previously only included the migration script, with no way to seed the database after a first deploy. This makes it possible to run `db:seed` manually against a production database when needed.

**What changed:**

- `Dockerfile`: The build stage now bundles `seed.ts` into `seed.mjs` (same pattern as `migrate.ts`). The production stage copies both `seed.mjs` and the `test/db/` JSON fixtures into the image.
- `package.json`: Added a `db:seed:prod` convenience script.

**How to seed after first deploy:**

```sh
docker exec <container> node /app/server/database/seed.mjs
```

`DATABASE_URL` must be set in the container environment (same requirement as migrations). The seed script is idempotent -- all inserts use `ON CONFLICT DO NOTHING`, so running it against a partially-seeded or already-seeded database is safe.