### PR TITLE
Add bulk participant import from Excel

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2638,22 +2638,6 @@
         "node": ">=18.12.0"
       }
     },
-    "node_modules/@nuxt/test-utils/node_modules/crossws": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/crossws/-/crossws-0.4.5.tgz",
-      "integrity": "sha512-wUR89x/Rw7/8t+vn0CmGDYM9TD6VtARGb0LD5jq2wjtMy1vCP4M+sm6N6TigWeTYvnA8MoW29NqqXD0ep0rfBA==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "peerDependencies": {
-        "srvx": ">=0.11.5"
-      },
-      "peerDependenciesMeta": {
-        "srvx": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@nuxt/test-utils/node_modules/estree-walker": {
       "version": "3.0.3",
       "license": "MIT",
@@ -11363,7 +11347,6 @@
     },
     "node_modules/playwright/node_modules/fsevents": {
       "version": "2.3.2",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [

--- a/pages/admin/events/[id]/invitees.vue
+++ b/pages/admin/events/[id]/invitees.vue
@@ -190,6 +190,98 @@ async function inviteAll() {
   }
 }
 
+// Import dialog
+const importDialog = ref(false)
+const importPasteText = ref('')
+const importRegister = ref(false)
+const importPassword = ref('EurocatsBBVA2026')
+const importRole = ref<InviteeRole>('participant')
+const importing = ref(false)
+
+interface ParsedRow {
+  fullName: string
+  firstName: string
+  lastName: string
+  email: string
+  valid: boolean
+  error?: string
+}
+
+function splitName(fullName: string): { firstName: string; lastName: string } {
+  const trimmed = fullName.trim().replace(/\s+/g, ' ')
+  const spaceIdx = trimmed.indexOf(' ')
+  if (spaceIdx === -1) return { firstName: '', lastName: trimmed }
+  return { firstName: trimmed.slice(0, spaceIdx), lastName: trimmed.slice(spaceIdx + 1) }
+}
+
+const parsedImportRows = computed<ParsedRow[]>(() => {
+  if (!importPasteText.value.trim()) return []
+  const lines = importPasteText.value.split('\n').map(l => l.trim()).filter(Boolean)
+  const seen = new Set<string>()
+  return lines.map((line) => {
+    const parts = line.split('\t')
+    const fullName = (parts[0] ?? '').trim()
+    const email = (parts[1] ?? '').trim().toLowerCase()
+
+    if (!fullName) return { fullName, firstName: '', lastName: '', email, valid: false, error: 'Missing name' }
+    if (!email) return { fullName, firstName: '', lastName: '', email, valid: false, error: 'Missing email' }
+    if (!/.+@.+\..+/.test(email)) return { fullName, firstName: '', lastName: '', email, valid: false, error: 'Invalid email' }
+    if (seen.has(email)) return { fullName, firstName: '', lastName: '', email, valid: false, error: 'Duplicate email' }
+    seen.add(email)
+
+    const { firstName, lastName } = splitName(fullName)
+    if (!lastName) return { fullName, firstName, lastName, email, valid: false, error: 'Cannot parse name' }
+
+    return { fullName, firstName, lastName, email, valid: true }
+  })
+})
+
+const validImportRows = computed(() => parsedImportRows.value.filter(r => r.valid))
+const canImport = computed(() =>
+  validImportRows.value.length > 0
+  && (!importRegister.value || importPassword.value.length >= 8),
+)
+
+function openImportDialog() {
+  importPasteText.value = ''
+  importRegister.value = false
+  importPassword.value = 'EurocatsBBVA2026'
+  importRole.value = 'participant'
+  importDialog.value = true
+}
+
+async function submitImport() {
+  if (!canImport.value) return
+  importing.value = true
+  try {
+    const result = await $fetch<{ imported: number; skipped: number; registered: number }>(
+      `/api/events/${eventId}/invitees/import`,
+      {
+        method: 'POST',
+        body: {
+          participants: validImportRows.value.map(r => ({ fullName: r.fullName, email: r.email })),
+          role: importRole.value,
+          registerParticipants: importRegister.value,
+          defaultPassword: importRegister.value ? importPassword.value : undefined,
+        },
+      },
+    )
+    const msg = `Imported ${result.imported} participant(s)`
+      + (result.skipped > 0 ? `, ${result.skipped} skipped (already exist)` : '')
+      + (result.registered > 0 ? `, ${result.registered} registered` : '')
+    showSnackbar(msg)
+    importDialog.value = false
+    await refresh()
+  }
+  catch (err: unknown) {
+    const message = (err as { data?: { message?: string } })?.data?.message || 'Import failed'
+    showSnackbar(message, 'error')
+  }
+  finally {
+    importing.value = false
+  }
+}
+
 // Delete
 const deleteDialog = ref(false)
 const deletingInvitee = ref<Invitee | null>(null)
@@ -234,6 +326,13 @@ async function deleteInvitee() {
           @click="inviteAll"
         >
           Invite All
+        </v-btn>
+        <v-btn
+          color="teal"
+          prepend-icon="mdi-table-arrow-right"
+          @click="openImportDialog"
+        >
+          Import
         </v-btn>
         <v-btn
           color="primary"
@@ -380,6 +479,96 @@ async function deleteInvitee() {
             @click="deleteInvitee"
           >
             Delete
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+
+    <!-- Import Dialog -->
+    <v-dialog v-model="importDialog" max-width="800">
+      <v-card>
+        <v-card-title>Import Participants</v-card-title>
+        <v-card-text>
+          <p class="text-body-2 mb-3">
+            Paste two columns copied from Excel: <strong>Full Name</strong> (tab) <strong>Email</strong> — one row per line.
+          </p>
+          <v-textarea
+            v-model="importPasteText"
+            label="Paste Excel data here"
+            placeholder="John Doe	john@example.com
+Jane Smith	jane@example.com"
+            rows="6"
+            variant="outlined"
+            class="mb-3"
+          />
+
+          <div v-if="parsedImportRows.length > 0" class="mb-4">
+            <p class="text-subtitle-2 mb-2">
+              Preview — {{ validImportRows.length }} valid / {{ parsedImportRows.length - validImportRows.length }} invalid
+            </p>
+            <v-table density="compact" class="border rounded">
+              <thead>
+                <tr>
+                  <th>First Name</th>
+                  <th>Last Name</th>
+                  <th>Email</th>
+                  <th>Status</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr
+                  v-for="(row, i) in parsedImportRows"
+                  :key="i"
+                  :class="row.valid ? '' : 'bg-red-lighten-5'"
+                >
+                  <td>{{ row.firstName }}</td>
+                  <td>{{ row.lastName }}</td>
+                  <td>{{ row.email }}</td>
+                  <td>
+                    <v-chip v-if="row.valid" color="green" size="x-small">OK</v-chip>
+                    <v-chip v-else color="error" size="x-small" :title="row.error">{{ row.error }}</v-chip>
+                  </td>
+                </tr>
+              </tbody>
+            </v-table>
+          </div>
+
+          <v-select
+            v-model="importRole"
+            :items="roleOptions"
+            item-title="title"
+            item-value="value"
+            label="Role"
+            class="mb-3"
+          />
+
+          <v-switch
+            v-model="importRegister"
+            label="Register participants immediately (create accounts with default password)"
+            color="primary"
+            class="mb-2"
+          />
+
+          <v-text-field
+            v-if="importRegister"
+            v-model="importPassword"
+            label="Default Password"
+            :rules="[(v: string) => v.length >= 8 || 'Password must be at least 8 characters']"
+            class="mb-2"
+          />
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer />
+          <v-btn variant="text" @click="importDialog = false">
+            Cancel
+          </v-btn>
+          <v-btn
+            color="teal"
+            :loading="importing"
+            :disabled="!canImport"
+            @click="submitImport"
+          >
+            Import {{ validImportRows.length > 0 ? `(${validImportRows.length})` : '' }}
           </v-btn>
         </v-card-actions>
       </v-card>

--- a/server/routes/api/events/[eventId]/invitees/import.post.ts
+++ b/server/routes/api/events/[eventId]/invitees/import.post.ts
@@ -1,0 +1,138 @@
+import { eq } from 'drizzle-orm'
+import { invitees, users, userEvents, inviteeRoleValues } from '~/server/database/schema'
+import type { InviteeRole } from '~/server/database/schema'
+
+const logger = useLogger('invitees-import')
+
+interface ParticipantInput {
+  fullName: string
+  email: string
+}
+
+function splitName(fullName: string): { firstName: string; lastName: string } {
+  const trimmed = fullName.trim().replace(/\s+/g, ' ')
+  const spaceIdx = trimmed.indexOf(' ')
+  if (spaceIdx === -1) {
+    return { firstName: '', lastName: trimmed }
+  }
+  return {
+    firstName: trimmed.slice(0, spaceIdx),
+    lastName: trimmed.slice(spaceIdx + 1),
+  }
+}
+
+export default defineEventHandler(async (event) => {
+  const eventId = getRouterParam(event, 'eventId')
+  if (!eventId) {
+    throw createError({ statusCode: 400, statusMessage: 'Event ID is required' })
+  }
+  await requireAdminOrStaff(event, eventId)
+
+  const body = await readBody<{
+    participants: ParticipantInput[]
+    role?: InviteeRole
+    registerParticipants?: boolean
+    defaultPassword?: string
+  }>(event)
+
+  if (!Array.isArray(body.participants) || body.participants.length === 0) {
+    throw createError({ statusCode: 400, statusMessage: 'participants must be a non-empty array' })
+  }
+
+  if (body.participants.length > 500) {
+    throw createError({ statusCode: 400, statusMessage: 'Cannot import more than 500 participants at once' })
+  }
+
+  const role: InviteeRole = body.role && inviteeRoleValues.includes(body.role) ? body.role : 'participant'
+  const registerParticipants = body.registerParticipants === true
+
+  if (registerParticipants) {
+    if (!body.defaultPassword || body.defaultPassword.length < 8) {
+      throw createError({ statusCode: 400, statusMessage: 'defaultPassword must be at least 8 characters when registerParticipants is true' })
+    }
+  }
+
+  // Normalise and deduplicate by email (keep first occurrence per email)
+  const seen = new Set<string>()
+  const rows: { firstName: string; lastName: string; email: string }[] = []
+  const skippedDuplicateInPayload: string[] = []
+
+  for (const p of body.participants) {
+    if (!p.email || !p.fullName) {
+      continue
+    }
+    const email = p.email.trim().toLowerCase()
+    if (!email || seen.has(email)) {
+      if (seen.has(email)) skippedDuplicateInPayload.push(email)
+      continue
+    }
+    seen.add(email)
+    const { firstName, lastName } = splitName(p.fullName)
+    if (!lastName) {
+      continue
+    }
+    rows.push({ firstName, lastName, email })
+  }
+
+  if (rows.length === 0) {
+    throw createError({ statusCode: 400, statusMessage: 'No valid participants found in the import data' })
+  }
+
+  const db = useDB()
+
+  let importedCount = 0
+  let registeredCount = 0
+
+  const passwordHash = registerParticipants ? await hashPassword(body.defaultPassword!) : null
+
+  await db.transaction(async (tx) => {
+    for (const row of rows) {
+      // Insert invitee; skip if (eventId, email) already exists
+      const [insertedInvitee] = await tx
+        .insert(invitees)
+        .values({ eventId, firstName: row.firstName, lastName: row.lastName, email: row.email, role })
+        .onConflictDoNothing()
+        .returning({ id: invitees.id })
+
+      if (insertedInvitee) {
+        importedCount++
+      }
+
+      if (registerParticipants) {
+        // Insert user if not exists, then get the user id
+        const [insertedUser] = await tx
+          .insert(users)
+          .values({ firstName: row.firstName, lastName: row.lastName, email: row.email, passwordHash })
+          .onConflictDoNothing()
+          .returning({ id: users.id })
+
+        const userId = insertedUser?.id
+          ?? (await tx.select({ id: users.id }).from(users).where(eq(users.email, row.email)).limit(1))[0]?.id
+
+        if (userId) {
+          const [insertedMembership] = await tx
+            .insert(userEvents)
+            .values({ userId, eventId })
+            .onConflictDoNothing()
+            .returning({ userId: userEvents.userId })
+
+          if (insertedMembership) {
+            registeredCount++
+          }
+        }
+      }
+    }
+  })
+
+  const skippedCount = rows.length - importedCount
+
+  logger.info(
+    `Bulk import for event ${eventId}: ${importedCount} imported, ${skippedCount} skipped, ${registeredCount} registered`,
+  )
+
+  return {
+    imported: importedCount,
+    skipped: skippedCount,
+    registered: registeredCount,
+  }
+})

--- a/test/api/invitees-import.test.ts
+++ b/test/api/invitees-import.test.ts
@@ -1,0 +1,273 @@
+import { describe, it, expect, beforeAll } from 'vitest'
+import { setup, fetch } from '@nuxt/test-utils/e2e'
+import { fileURLToPath } from 'node:url'
+import {
+  migrateAndSeed,
+  loginAs,
+  ADMIN_EMAIL,
+  REGULAR_USER_EMAIL,
+  STAFF_USER_EMAIL,
+  PARTICIPANT_USER_EMAIL,
+  OUTSIDER_EMAIL,
+  TEST_EVENT_ID,
+} from './helpers'
+
+const IMPORT_URL = `/api/events/${TEST_EVENT_ID}/invitees/import`
+
+describe('Invitees Import Endpoint', async () => {
+  let adminCookies: string
+  let participantCookies: string
+  let staffCookies: string
+  let outsiderCookies: string
+
+  await setup({
+    rootDir: fileURLToPath(new URL('../..', import.meta.url)),
+    env: {
+      AUTH_MODE: 'local',
+      NUXT_AUTH_MODE: 'local',
+      NUXT_PUBLIC_AUTH_MODE: 'local',
+      ADMIN_EMAILS: ADMIN_EMAIL,
+      NUXT_SESSION_PASSWORD: 'test-session-secret-that-is-at-least-32-chars-long',
+      SMTP_HOST: 'localhost',
+      SMTP_PORT: '2525',
+      APP_URL: 'http://localhost:3000',
+    },
+  })
+
+  beforeAll(async () => {
+    await migrateAndSeed()
+    adminCookies = await loginAs(fetch, ADMIN_EMAIL)
+    participantCookies = await loginAs(fetch, PARTICIPANT_USER_EMAIL)
+    staffCookies = await loginAs(fetch, STAFF_USER_EMAIL)
+    outsiderCookies = await loginAs(fetch, OUTSIDER_EMAIL)
+  })
+
+  // ─── Auth ─────────────────────────────────────────────────────────
+
+  it('returns 401 when unauthenticated', async () => {
+    const res = await fetch(IMPORT_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ participants: [{ fullName: 'Test User', email: 'test@example.com' }] }),
+    })
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 403 for a non-staff participant of the event', async () => {
+    const res = await fetch(IMPORT_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Cookie: participantCookies },
+      body: JSON.stringify({ participants: [{ fullName: 'Test User', email: 'test@example.com' }] }),
+    })
+    expect(res.status).toBe(403)
+  })
+
+  it('returns 403 for a user who is not an invitee of the event at all', async () => {
+    const res = await fetch(IMPORT_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Cookie: outsiderCookies },
+      body: JSON.stringify({ participants: [{ fullName: 'Test User', email: 'test@example.com' }] }),
+    })
+    expect(res.status).toBe(403)
+  })
+
+  // ─── Validation ───────────────────────────────────────────────────
+
+  it('returns 400 when participants is missing', async () => {
+    const res = await fetch(IMPORT_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Cookie: adminCookies },
+      body: JSON.stringify({}),
+    })
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 when participants is empty', async () => {
+    const res = await fetch(IMPORT_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Cookie: adminCookies },
+      body: JSON.stringify({ participants: [] }),
+    })
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 when registerParticipants is true but defaultPassword is missing', async () => {
+    const res = await fetch(IMPORT_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Cookie: adminCookies },
+      body: JSON.stringify({
+        participants: [{ fullName: 'Test User', email: 'newuser@example.com' }],
+        registerParticipants: true,
+      }),
+    })
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 when registerParticipants is true but defaultPassword is too short', async () => {
+    const res = await fetch(IMPORT_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Cookie: adminCookies },
+      body: JSON.stringify({
+        participants: [{ fullName: 'Test User', email: 'newuser2@example.com' }],
+        registerParticipants: true,
+        defaultPassword: 'short',
+      }),
+    })
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 when all rows are invalid (no valid rows remain)', async () => {
+    const res = await fetch(IMPORT_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Cookie: adminCookies },
+      body: JSON.stringify({
+        participants: [
+          { fullName: '', email: 'noemail@example.com' },
+          { fullName: 'No Email', email: '' },
+        ],
+      }),
+    })
+    expect(res.status).toBe(400)
+  })
+
+  // ─── Happy path ───────────────────────────────────────────────────
+
+  it('imports new invitees successfully as admin', async () => {
+    const res = await fetch(IMPORT_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Cookie: adminCookies },
+      body: JSON.stringify({
+        participants: [
+          { fullName: 'Imported One', email: 'imported.one@example.com' },
+          { fullName: 'Imported Two', email: 'imported.two@example.com' },
+        ],
+      }),
+    })
+    expect(res.status).toBe(200)
+    const body = await res.json() as { imported: number; skipped: number; registered: number }
+    expect(body.imported).toBe(2)
+    expect(body.skipped).toBe(0)
+    expect(body.registered).toBe(0)
+
+    // Verify via GET
+    const listRes = await fetch(`/api/events/${TEST_EVENT_ID}/invitees`, {
+      headers: { Cookie: adminCookies },
+    })
+    const list = await listRes.json() as Array<{ email: string; firstName: string; lastName: string }>
+    const emails = list.map(i => i.email)
+    expect(emails).toContain('imported.one@example.com')
+    expect(emails).toContain('imported.two@example.com')
+
+    const one = list.find(i => i.email === 'imported.one@example.com')
+    expect(one?.firstName).toBe('Imported')
+    expect(one?.lastName).toBe('One')
+  })
+
+  it('allows staff to import invitees', async () => {
+    const res = await fetch(IMPORT_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Cookie: staffCookies },
+      body: JSON.stringify({
+        participants: [{ fullName: 'Staff Imported', email: 'staff.imported@example.com' }],
+      }),
+    })
+    expect(res.status).toBe(200)
+    const body = await res.json() as { imported: number }
+    expect(body.imported).toBe(1)
+  })
+
+  it('skips already-existing invitees and reports counts correctly', async () => {
+    // alice@example.com is already in the seed data
+    const res = await fetch(IMPORT_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Cookie: adminCookies },
+      body: JSON.stringify({
+        participants: [
+          { fullName: 'Alice Smith', email: 'alice@example.com' },
+          { fullName: 'Brand New', email: 'brand.new@example.com' },
+        ],
+      }),
+    })
+    expect(res.status).toBe(200)
+    const body = await res.json() as { imported: number; skipped: number }
+    expect(body.imported).toBe(1)
+    expect(body.skipped).toBe(1)
+  })
+
+  it('deduplicates duplicate emails within the same payload', async () => {
+    const res = await fetch(IMPORT_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Cookie: adminCookies },
+      body: JSON.stringify({
+        participants: [
+          { fullName: 'Dup User', email: 'dup.user@example.com' },
+          { fullName: 'Dup User Again', email: 'dup.user@example.com' },
+        ],
+      }),
+    })
+    expect(res.status).toBe(200)
+    const body = await res.json() as { imported: number }
+    expect(body.imported).toBe(1)
+  })
+
+  it('handles multi-word last names correctly', async () => {
+    const res = await fetch(IMPORT_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Cookie: adminCookies },
+      body: JSON.stringify({
+        participants: [{ fullName: 'Jan van der Berg', email: 'jan.vdberg@example.com' }],
+      }),
+    })
+    expect(res.status).toBe(200)
+    const listRes = await fetch(`/api/events/${TEST_EVENT_ID}/invitees`, { headers: { Cookie: adminCookies } })
+    const list = await listRes.json() as Array<{ email: string; firstName: string; lastName: string }>
+    const entry = list.find(i => i.email === 'jan.vdberg@example.com')
+    expect(entry?.firstName).toBe('Jan')
+    expect(entry?.lastName).toBe('van der Berg')
+  })
+
+  it('imports with registerParticipants=true, creating user accounts and event membership', async () => {
+    const email = 'registered.import@example.com'
+    const res = await fetch(IMPORT_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Cookie: adminCookies },
+      body: JSON.stringify({
+        participants: [{ fullName: 'Registered Import', email }],
+        registerParticipants: true,
+        defaultPassword: 'EurocatsBBVA2026',
+      }),
+    })
+    expect(res.status).toBe(200)
+    const body = await res.json() as { imported: number; registered: number }
+    expect(body.imported).toBe(1)
+    expect(body.registered).toBe(1)
+
+    // User should be able to log in with the default password
+    const loginRes = await fetch('/api/auth/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, password: 'EurocatsBBVA2026' }),
+    })
+    expect(loginRes.status).toBe(200)
+  })
+
+  it('registerParticipants=true skips existing users but still links them to the event', async () => {
+    // diana.rivera@example.com already exists as a user in seed data
+    const email = REGULAR_USER_EMAIL
+    const res = await fetch(IMPORT_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Cookie: adminCookies },
+      body: JSON.stringify({
+        participants: [{ fullName: 'Diana Rivera', email }],
+        registerParticipants: true,
+        defaultPassword: 'EurocatsBBVA2026',
+      }),
+    })
+    expect(res.status).toBe(200)
+    // The user already existed AND was already in this event → both skipped, no error
+    const body = await res.json() as { imported: number; skipped: number; registered: number }
+    expect(body.imported).toBe(0) // already an invitee
+    expect(body.skipped).toBe(1)
+    expect(body.registered).toBe(0) // already a member of the event
+  })
+})


### PR DESCRIPTION
## Why

Admins needed a way to bulk-import participants by pasting two columns (full name + email) copied directly from Excel, rather than adding people one at a time. The optional registration flag lets organizers pre-create accounts with a shared default password so participants can log in immediately without going through the invitation flow.

## What changed

**New API endpoint: `POST /api/events/:eventId/invitees/import`**

Accepts a list of `{ fullName, email }` rows plus optional flags:
- `role` (defaults to `participant`)
- `registerParticipants` -- when `true`, creates user accounts with `defaultPassword` and links them to the event via `userEvents`

Key design decisions:
- Names are split on the first space; everything after the first token becomes `lastName` (handles "Jan van der Berg" correctly)
- Emails are lowercased/trimmed before all DB operations
- Duplicate emails within the same payload are deduplicated before any writes
- The entire operation runs in a single transaction
- Existing invitees (same `eventId` + `email`) and existing user accounts are silently skipped via `onConflictDoNothing`; existing users are still linked to the event if not already members
- Returns `{ imported, skipped, registered }` so the UI can report a meaningful summary

**New Import dialog on the Invitees admin page**

- "Import" button opens a dialog with a paste textarea (Tab-separated: name + email, one row per line)
- Live preview table shows parsed firstName / lastName / email with per-row validation status (invalid rows are highlighted and excluded from the import)
- Role selector and a "Register participants immediately" toggle; when enabled, a password field appears pre-filled with `EurocatsBBVA2026`
- Import button label shows the valid-row count before clicking

**15 integration tests** covering: 401/403 auth, all validation paths, happy-path import, staff access, duplicate skipping, multi-word last names, registration with default password, and the existing-user/existing-membership edge cases.