### PR TITLE
Add registration option to manual participant creation

### DIFF
--- a/pages/admin/events/[id]/invitees.vue
+++ b/pages/admin/events/[id]/invitees.vue
@@ -82,7 +82,7 @@ function getInvitationStatus(invitee: Invitee): { label: string; color: string }
 // Dialog state
 const dialog = ref(false)
 const editingInvitee = ref<Invitee | null>(null)
-const form = ref({ firstName: '', lastName: '', email: '', role: 'participant' as InviteeRole })
+const form = ref({ firstName: '', lastName: '', email: '', role: 'participant' as InviteeRole, registerParticipant: false, defaultPassword: 'EurocatsBBVA2026' })
 const formValid = ref(false)
 const saving = ref(false)
 
@@ -96,7 +96,7 @@ const rules = {
 
 function openAddDialog() {
   editingInvitee.value = null
-  form.value = { firstName: '', lastName: '', email: '', role: 'participant' }
+  form.value = { firstName: '', lastName: '', email: '', role: 'participant', registerParticipant: false, defaultPassword: 'EurocatsBBVA2026' }
   dialog.value = true
 }
 
@@ -107,6 +107,8 @@ function openEditDialog(invitee: Invitee) {
     lastName: invitee.lastName,
     email: invitee.email,
     role: invitee.role,
+    registerParticipant: false,
+    defaultPassword: 'EurocatsBBVA2026',
   }
   dialog.value = true
 }
@@ -129,15 +131,22 @@ async function saveInvitee() {
     if (editingInvitee.value) {
       await $fetch(`/api/events/${eventId}/invitees/${editingInvitee.value.id}`, {
         method: 'PUT',
-        body: form.value,
+        body: { firstName: form.value.firstName, lastName: form.value.lastName, email: form.value.email, role: form.value.role },
       })
       showSnackbar('Invitee updated successfully')
     }
     else {
-      await $fetch(`/api/events/${eventId}/invitees`, {
-        method: 'POST',
-        body: form.value,
-      })
+      const body: Record<string, unknown> = {
+        firstName: form.value.firstName,
+        lastName: form.value.lastName,
+        email: form.value.email,
+        role: form.value.role,
+      }
+      if (form.value.registerParticipant) {
+        body.registerParticipant = true
+        body.defaultPassword = form.value.defaultPassword
+      }
+      await $fetch(`/api/events/${eventId}/invitees`, { method: 'POST', body })
       showSnackbar('Invitee added successfully')
     }
     dialog.value = false
@@ -440,6 +449,22 @@ async function deleteInvitee() {
               item-title="title"
               item-value="value"
             />
+
+            <template v-if="!editingInvitee">
+              <v-switch
+                v-model="form.registerParticipant"
+                label="Register participant immediately (create account with default password)"
+                color="primary"
+                class="mt-2 mb-1"
+              />
+              <v-text-field
+                v-if="form.registerParticipant"
+                v-model="form.defaultPassword"
+                label="Default Password"
+                :rules="[(v: string) => v.length >= 8 || 'Password must be at least 8 characters']"
+                class="mb-2"
+              />
+            </template>
           </v-form>
         </v-card-text>
         <v-card-actions>

--- a/server/routes/api/events/[eventId]/invitees/index.post.ts
+++ b/server/routes/api/events/[eventId]/invitees/index.post.ts
@@ -1,4 +1,5 @@
-import { invitees, inviteeRoleValues } from '~/server/database/schema'
+import { eq } from 'drizzle-orm'
+import { invitees, users, userEvents, inviteeRoleValues } from '~/server/database/schema'
 import type { InviteeRole } from '~/server/database/schema'
 
 const logger = useLogger('invitees')
@@ -10,7 +11,14 @@ export default defineEventHandler(async (event) => {
   }
   await requireAdminOrStaff(event, eventId)
 
-  const body = await readBody<{ firstName: string; lastName: string; email: string; role?: InviteeRole }>(event)
+  const body = await readBody<{
+    firstName: string
+    lastName: string
+    email: string
+    role?: InviteeRole
+    registerParticipant?: boolean
+    defaultPassword?: string
+  }>(event)
 
   if (!body.firstName || !body.lastName || !body.email) {
     throw createError({ statusCode: 400, statusMessage: 'firstName, lastName, and email are required' })
@@ -20,17 +28,66 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 400, statusMessage: `role must be one of: ${inviteeRoleValues.join(', ')}` })
   }
 
-  const [created] = await useDB()
-    .insert(invitees)
-    .values({
-      eventId,
-      firstName: body.firstName,
-      lastName: body.lastName,
-      email: body.email,
-      role: body.role ?? 'participant',
-    })
-    .returning()
+  const registerParticipant = body.registerParticipant === true
 
-  logger.info(`Invitee added: ${created.email} to event ${eventId} (role: ${created.role})`)
-  return created
+  if (registerParticipant) {
+    if (!body.defaultPassword || body.defaultPassword.length < 8) {
+      throw createError({ statusCode: 400, statusMessage: 'defaultPassword must be at least 8 characters when registerParticipant is true' })
+    }
+  }
+
+  const db = useDB()
+  let created: typeof invitees.$inferSelect
+  let registered = false
+
+  if (registerParticipant) {
+    const passwordHash = await hashPassword(body.defaultPassword!)
+
+    await db.transaction(async (tx) => {
+      const [insertedInvitee] = await tx
+        .insert(invitees)
+        .values({
+          eventId,
+          firstName: body.firstName,
+          lastName: body.lastName,
+          email: body.email,
+          role: body.role ?? 'participant',
+        })
+        .returning()
+      created = insertedInvitee
+
+      const [insertedUser] = await tx
+        .insert(users)
+        .values({ firstName: body.firstName, lastName: body.lastName, email: body.email, passwordHash })
+        .onConflictDoNothing()
+        .returning({ id: users.id })
+
+      const userId = insertedUser?.id
+        ?? (await tx.select({ id: users.id }).from(users).where(eq(users.email, body.email)).limit(1))[0]?.id
+
+      if (userId) {
+        await tx
+          .insert(userEvents)
+          .values({ userId, eventId })
+          .onConflictDoNothing()
+        registered = true
+      }
+    })
+  }
+  else {
+    const [insertedInvitee] = await db
+      .insert(invitees)
+      .values({
+        eventId,
+        firstName: body.firstName,
+        lastName: body.lastName,
+        email: body.email,
+        role: body.role ?? 'participant',
+      })
+      .returning()
+    created = insertedInvitee
+  }
+
+  logger.info(`Invitee added: ${created!.email} to event ${eventId} (role: ${created!.role}, registered: ${registered})`)
+  return { ...created!, registered }
 })

--- a/test/api/endpoints.test.ts
+++ b/test/api/endpoints.test.ts
@@ -392,6 +392,62 @@ describe('Events Endpoints', async () => {
       const invitee = await res.json() as Record<string, unknown>
       expect(invitee.role).toBe('staff')
     })
+
+    it('returns 400 when registerParticipant is true but no password provided', async () => {
+      const res = await fetch(`/api/events/${TEST_EVENT_ID}/invitees`, {
+        method: 'POST',
+        headers: { Cookie: adminCookies, 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          firstName: 'Reg',
+          lastName: 'NoPass',
+          email: 'reg.nopass@example.com',
+          registerParticipant: true,
+        }),
+      })
+      expect(res.status).toBe(400)
+    })
+
+    it('returns 400 when registerParticipant is true but password is too short', async () => {
+      const res = await fetch(`/api/events/${TEST_EVENT_ID}/invitees`, {
+        method: 'POST',
+        headers: { Cookie: adminCookies, 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          firstName: 'Reg',
+          lastName: 'ShortPass',
+          email: 'reg.shortpass@example.com',
+          registerParticipant: true,
+          defaultPassword: 'short',
+        }),
+      })
+      expect(res.status).toBe(400)
+    })
+
+    it('creates invitee and registers user when registerParticipant is true', async () => {
+      const res = await fetch(`/api/events/${TEST_EVENT_ID}/invitees`, {
+        method: 'POST',
+        headers: { Cookie: adminCookies, 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          firstName: 'Registered',
+          lastName: 'Manual',
+          email: 'registered.manual@example.com',
+          registerParticipant: true,
+          defaultPassword: 'EurocatsBBVA2026',
+        }),
+      })
+      expect(res.status).toBe(200)
+      const invitee = await res.json() as Record<string, unknown>
+      expect(invitee.firstName).toBe('Registered')
+      expect(invitee.email).toBe('registered.manual@example.com')
+      expect(invitee.registered).toBe(true)
+
+      // The registered user can log in with the default password
+      const loginRes = await fetch('/api/auth/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: 'registered.manual@example.com', password: 'EurocatsBBVA2026' }),
+      })
+      expect(loginRes.status).toBe(200)
+    })
   })
 
   describe('PUT /api/events/:eventId/invitees/:id', () => {


### PR DESCRIPTION
When adding a participant manually, admins can now optionally register them immediately - creating a user account and event membership with a default password - mirroring exactly what the CSV bulk import already supports.

## What changed

**Backend (`index.post.ts`):** The single-participant POST endpoint now accepts two optional fields: `registerParticipant: boolean` and `defaultPassword: string`. When `registerParticipant` is `true`, it validates the password (min 8 chars), then inside a single transaction: inserts the invitee, upserts the user record with a bcrypt-hashed password, and creates the `userEvents` link. If the user already exists, it reuses the existing account. The response includes a `registered: boolean` field.

**Frontend (`invitees.vue`):** The "Add Invitee" dialog gains a register toggle and a default password field (pre-filled with `EurocatsBBVA2026`), shown only when adding (not editing, since re-registration does not apply to existing invitees). The registration fields are only sent to the API when the toggle is on.

**Tests (`endpoints.test.ts`):** Three new cases for the POST `/invitees` endpoint:
- 400 when `registerParticipant: true` but no password provided
- 400 when password is shorter than 8 characters
- 200 happy path - verifies `registered: true` in the response and that the created user can log in with the default password