### PR TITLE
Exclude moderators and staff from introduction round dispatch

### DIFF
--- a/server/routes/api/events/[eventId]/introduction-round/dispatch.post.ts
+++ b/server/routes/api/events/[eventId]/introduction-round/dispatch.post.ts
@@ -1,5 +1,5 @@
-import { eq, and, inArray } from 'drizzle-orm'
-import { events, introductionRounds, introductionSlotAssignments, userEvents, users, rooms } from '~/server/database/schema'
+import { eq, and, inArray, or, isNull } from 'drizzle-orm'
+import { events, introductionRounds, introductionSlotAssignments, userEvents, users, invitees, rooms } from '~/server/database/schema'
 import { dispatchIntroductionRound } from '~/server/utils/introductionAlgorithm'
 
 const logger = useLogger('introduction-round')
@@ -29,12 +29,16 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 404, statusMessage: 'No introduction round configured for this event' })
   }
 
-  // Fetch registered participants (users with user_events records for this event)
+  // Fetch registered participants, excluding moderators and staff
   const participantRows = await db
     .select({ userId: users.id, email: users.email })
     .from(userEvents)
     .innerJoin(users, eq(userEvents.userId, users.id))
-    .where(and(eq(userEvents.eventId, eventId)))
+    .leftJoin(invitees, and(eq(invitees.email, users.email), eq(invitees.eventId, eventId)))
+    .where(and(
+      eq(userEvents.eventId, eventId),
+      or(isNull(invitees.role), eq(invitees.role, 'participant')),
+    ))
 
   if (participantRows.length === 0) {
     throw createError({ statusCode: 400, statusMessage: 'No registered participants found for this event' })

--- a/test/api/introduction-round.test.ts
+++ b/test/api/introduction-round.test.ts
@@ -6,6 +6,7 @@ import {
   loginAs,
   ADMIN_EMAIL,
   REGULAR_USER_EMAIL,
+  PARTICIPANT_USER_EMAIL,
   TEST_EVENT_ID,
 } from './helpers'
 
@@ -14,6 +15,7 @@ const BASE = `/api/events/${TEST_EVENT_ID}/introduction-round`
 describe('Introduction Round Endpoints', async () => {
   let adminCookies: string
   let userCookies: string
+  let participantCookies: string
 
   await setup({
     rootDir: fileURLToPath(new URL('../..', import.meta.url)),
@@ -33,6 +35,7 @@ describe('Introduction Round Endpoints', async () => {
     await migrateAndSeed()
     adminCookies = await loginAs(fetch, ADMIN_EMAIL)
     userCookies = await loginAs(fetch, REGULAR_USER_EMAIL)
+    participantCookies = await loginAs(fetch, PARTICIPANT_USER_EMAIL)
   })
 
   // ─── GET (no round yet) ──────────────────────────────────────────────────────
@@ -190,7 +193,7 @@ describe('Introduction Round Endpoints', async () => {
 
   describe('GET /api/events/[eventId]/introduction-round (open)', () => {
     it('returns 200 for participant with their own assignments', async () => {
-      const res = await fetch(BASE, { headers: { Cookie: userCookies } })
+      const res = await fetch(BASE, { headers: { Cookie: participantCookies } })
       expect(res.status).toBe(200)
       const body = await res.json()
       expect(body.status).toBe('open')
@@ -200,10 +203,19 @@ describe('Introduction Round Endpoints', async () => {
     })
 
     it('participant does not see other participants assignments', async () => {
-      const res = await fetch(BASE, { headers: { Cookie: userCookies } })
+      const res = await fetch(BASE, { headers: { Cookie: participantCookies } })
       const body = await res.json()
       // Participant view has myAssignments, not slots
       expect(body.slots).toBeUndefined()
+    })
+
+    it('moderator is excluded from introduction round assignments', async () => {
+      const res = await fetch(BASE, { headers: { Cookie: userCookies } })
+      expect(res.status).toBe(200)
+      const body = await res.json()
+      // Moderator has no assignments since they are excluded from dispatch
+      expect(Array.isArray(body.myAssignments)).toBe(true)
+      expect(body.myAssignments.length).toBe(0)
     })
 
     it('assignments satisfy no-same-domain-in-same-room constraint (best-effort)', async () => {


### PR DESCRIPTION
## Why

Introduction rounds are meant for participants to meet each other. Moderators and staff already know the event well and should not be mixed into participant introduction groups.

## What changed

**`dispatch.post.ts`** - The participants query now left-joins the `invitees` table and filters to only include users whose invitee role is `'participant'`, or who have no invitee record for the event. Moderators and staff are excluded before the assignment algorithm runs.

**`introduction-round.test.ts`** - Updated the participant-view assertions to use `noah.williams@example.com` (a true participant) instead of `diana.rivera@example.com` (a moderator). Added a new test that verifies a moderator gets zero assignments after dispatch.

## Notes

Users who registered for an event but have no matching invitee record are treated as participants and remain included - this preserves backward compatibility for admin accounts and any other users added outside the normal invite flow.