### PR TITLE
Add "Clear All Assignments" button to recover from broken assignment state

### DIFF
--- a/pages/admin/events/[id]/rounds/index.vue
+++ b/pages/admin/events/[id]/rounds/index.vue
@@ -33,6 +33,25 @@ const { data: rounds, status: fetchStatus, refresh } = useAsyncData(
   () => $fetch<RoundItem[]>(`/api/events/${eventId}/rounds`),
 )
 
+// ── Clear all assignments ─────────────────────────────────────────────────────
+const clearDialog = ref(false)
+const clearing = ref(false)
+const clearError = ref('')
+
+async function confirmClearAssignments() {
+  clearing.value = true
+  clearError.value = ''
+  try {
+    await $fetch(`/api/events/${eventId}/rounds/clear-assignments`, { method: 'POST' })
+    clearDialog.value = false
+    await refresh()
+  } catch (err: unknown) {
+    clearError.value = (err as { data?: { message?: string } })?.data?.message ?? 'Failed to clear assignments'
+  } finally {
+    clearing.value = false
+  }
+}
+
 // ── Create / Edit dialog ──────────────────────────────────────────────────────
 const dialog = ref(false)
 const deleteDialog = ref(false)
@@ -138,9 +157,20 @@ async function confirmDelete() {
 
     <div class="d-flex align-center justify-space-between mb-4">
       <h2 class="text-h6">Rounds</h2>
-      <v-btn color="deep-purple" prepend-icon="mdi-plus" @click="openCreate">
-        New Round
-      </v-btn>
+      <div class="d-flex ga-2">
+        <v-btn
+          v-if="rounds && rounds.length > 0"
+          color="error"
+          variant="outlined"
+          prepend-icon="mdi-database-remove-outline"
+          @click="clearDialog = true"
+        >
+          Clear All Assignments
+        </v-btn>
+        <v-btn color="deep-purple" prepend-icon="mdi-plus" @click="openCreate">
+          New Round
+        </v-btn>
+      </div>
     </div>
 
     <v-progress-linear v-if="fetchStatus === 'pending'" indeterminate color="deep-purple" class="mb-4" />
@@ -286,5 +316,29 @@ async function confirmDelete() {
         </v-card-actions>
       </v-card>
     </v-dialog>
+    <!-- Clear All Assignments Confirmation Dialog -->
+    <v-dialog v-model="clearDialog" max-width="480">
+      <v-card>
+        <v-card-title class="d-flex align-center ga-2">
+          <v-icon color="error">mdi-database-remove-outline</v-icon>
+          Clear All Assignments
+        </v-card-title>
+        <v-card-text>
+          <v-alert v-if="clearError" type="error" variant="tonal" class="mb-3">
+            {{ clearError }}
+          </v-alert>
+          This will delete all slots and participant registrations for <strong>every round</strong> in this event
+          and reset all rounds to <strong>draft</strong> status.
+          <br /><br />
+          Use this to recover from a broken assignment state. This action cannot be undone.
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer />
+          <v-btn variant="text" :disabled="clearing" @click="clearDialog = false">Cancel</v-btn>
+          <v-btn color="error" :loading="clearing" @click="confirmClearAssignments">Clear All Assignments</v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+
   </div>
 </template>

--- a/server/routes/api/events/[eventId]/rounds/clear-assignments.post.ts
+++ b/server/routes/api/events/[eventId]/rounds/clear-assignments.post.ts
@@ -1,0 +1,42 @@
+import { eq, inArray } from 'drizzle-orm'
+import { rounds, slots, slotRegistrations } from '~/server/database/schema'
+
+export default defineEventHandler(async (event) => {
+  const eventId = getRouterParam(event, 'eventId')
+  if (!eventId) {
+    throw createError({ statusCode: 400, statusMessage: 'Event ID is required' })
+  }
+
+  await requireAdmin(event)
+
+  const db = useDB()
+
+  const eventRounds = await db
+    .select({ id: rounds.id })
+    .from(rounds)
+    .where(eq(rounds.eventId, eventId))
+
+  if (eventRounds.length === 0) {
+    return { cleared: 0 }
+  }
+
+  const roundIds = eventRounds.map((r) => r.id)
+
+  const eventSlots = await db
+    .select({ id: slots.id })
+    .from(slots)
+    .where(inArray(slots.roundId, roundIds))
+
+  if (eventSlots.length > 0) {
+    const slotIds = eventSlots.map((s) => s.id)
+    await db.delete(slotRegistrations).where(inArray(slotRegistrations.slotId, slotIds))
+    await db.delete(slots).where(inArray(slots.id, slotIds))
+  }
+
+  await db
+    .update(rounds)
+    .set({ status: 'draft', updatedAt: new Date() })
+    .where(inArray(rounds.id, roundIds))
+
+  return { cleared: roundIds.length }
+})


### PR DESCRIPTION
## Why

After a round assignment reset, the app could end up in a broken state where subsequent assignment runs produce no sessions or participants -- even for newly created rounds. There was no way to recover without direct database access.

## What changed

**New API endpoint** -- `POST /api/events/:eventId/rounds/clear-assignments`

Wipes all assignment data for an event in one shot:
- Deletes all `slot_registrations` and `slots` for every round belonging to the event
- Resets every round's status back to `draft`
- Admin-only, returns `{ cleared: N }` (count of rounds reset)

**UI button** -- Rounds admin page (`/admin/events/:id/rounds`)

- A red outlined **"Clear All Assignments"** button appears in the header whenever the event has at least one round
- Clicking opens a confirmation dialog that explains the destructive nature of the action
- On confirm, calls the endpoint and refreshes the round list

## Notes

This is a recovery/escape-hatch tool, not part of the normal assignment workflow. The confirmation dialog makes the irreversible nature clear before committing. The per-round `reset` endpoint remains for cases where only one round needs to be cleared.