### PR TITLE
Add "Publish Scheduled" bulk action for event sessions

### DIFF
--- a/pages/admin/events/[id]/sessions.vue
+++ b/pages/admin/events/[id]/sessions.vue
@@ -174,6 +174,35 @@ function effectiveDuration(session: SessionItem): string {
   return `${def} min (default)`
 }
 
+// ── Publish Scheduled ─────────────────────────────────────────────────────────
+const publishScheduledDialog = ref(false)
+const publishingScheduled = ref(false)
+const publishScheduledError = ref('')
+const publishScheduledCount = ref<number | null>(null)
+
+const scheduledCount = computed(
+  () => allSessions.value?.filter(s => s.status === 'scheduled').length ?? 0,
+)
+
+async function confirmPublishScheduled() {
+  publishingScheduled.value = true
+  publishScheduledError.value = ''
+  try {
+    const result = await $fetch<{ published: number }>(
+      `/api/events/${eventId}/sessions/publish-scheduled`,
+      { method: 'POST' },
+    )
+    publishScheduledCount.value = result.published
+    publishScheduledDialog.value = false
+    await refresh()
+  } catch (err: unknown) {
+    publishScheduledError.value = (err as { data?: { message?: string } })?.data?.message
+      ?? 'Failed to publish sessions'
+  } finally {
+    publishingScheduled.value = false
+  }
+}
+
 const deleteDialog = ref(false)
 const deletingSession = ref<SessionItem | null>(null)
 const deleting = ref(false)
@@ -210,10 +239,31 @@ async function confirmDelete() {
 
     <div class="d-flex align-center justify-space-between mb-4">
       <h2 class="text-h6">Sessions</h2>
-      <v-btn color="primary" prepend-icon="mdi-plus" @click="openCreate">
-        Create Session
-      </v-btn>
+      <div class="d-flex ga-2">
+        <v-btn
+          color="green"
+          prepend-icon="mdi-publish"
+          :disabled="scheduledCount === 0"
+          @click="publishScheduledDialog = true; publishScheduledError = ''; publishScheduledCount = null"
+        >
+          Publish Scheduled ({{ scheduledCount }})
+        </v-btn>
+        <v-btn color="primary" prepend-icon="mdi-plus" @click="openCreate">
+          Create Session
+        </v-btn>
+      </div>
     </div>
+
+    <v-alert
+      v-if="publishScheduledCount !== null"
+      type="success"
+      variant="tonal"
+      closable
+      class="mb-4"
+      @click:close="publishScheduledCount = null"
+    >
+      {{ publishScheduledCount }} session{{ publishScheduledCount === 1 ? '' : 's' }} published successfully.
+    </v-alert>
 
     <!-- Status filter chips -->
     <div class="d-flex flex-wrap ga-2 mb-4">
@@ -402,6 +452,25 @@ async function confirmDelete() {
           <v-spacer />
           <v-btn variant="text" :disabled="deleting" @click="deleteDialog = false">Cancel</v-btn>
           <v-btn color="error" :loading="deleting" @click="confirmDelete">Delete</v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+    <!-- Publish Scheduled Confirmation Dialog -->
+    <v-dialog v-model="publishScheduledDialog" max-width="450">
+      <v-card>
+        <v-card-title>Publish Scheduled Sessions</v-card-title>
+        <v-card-text>
+          <v-alert v-if="publishScheduledError" type="error" variant="tonal" class="mb-3">
+            {{ publishScheduledError }}
+          </v-alert>
+          Are you sure you want to publish all <strong>{{ scheduledCount }}</strong>
+          scheduled session{{ scheduledCount === 1 ? '' : 's' }}? Their status will change
+          from <em>scheduled</em> to <em>published</em>.
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer />
+          <v-btn variant="text" :disabled="publishingScheduled" @click="publishScheduledDialog = false">Cancel</v-btn>
+          <v-btn color="green" :loading="publishingScheduled" @click="confirmPublishScheduled">Publish</v-btn>
         </v-card-actions>
       </v-card>
     </v-dialog>

--- a/server/routes/api/events/[eventId]/sessions/publish-scheduled.post.ts
+++ b/server/routes/api/events/[eventId]/sessions/publish-scheduled.post.ts
@@ -1,0 +1,24 @@
+import { eq, and } from 'drizzle-orm'
+import { sessions } from '~/server/database/schema'
+
+const logger = useLogger('sessions')
+
+export default defineEventHandler(async (event) => {
+  const eventId = getRouterParam(event, 'eventId')
+  if (!eventId) {
+    throw createError({ statusCode: 400, statusMessage: 'Event ID is required' })
+  }
+
+  await requireAdmin(event)
+
+  const db = useDB()
+
+  const result = await db
+    .update(sessions)
+    .set({ status: 'published', updatedAt: new Date() })
+    .where(and(eq(sessions.eventId, eventId), eq(sessions.status, 'scheduled')))
+    .returning({ id: sessions.id })
+
+  logger.info(`Published ${result.length} scheduled sessions for event ${eventId}`)
+  return { published: result.length }
+})

--- a/test/api/sessions.test.ts
+++ b/test/api/sessions.test.ts
@@ -768,4 +768,78 @@ describe('Sessions Endpoints', async () => {
       expect(res.status).toBe(400)
     })
   })
+
+  // ─── POST /sessions/publish-scheduled ────────────────────────────────────
+  describe('POST /api/events/[eventId]/sessions/publish-scheduled', () => {
+    const PUBLISH_URL = `${BASE}/publish-scheduled`
+
+    it('returns 401 for unauthenticated request', async () => {
+      const res = await fetch(PUBLISH_URL, { method: 'POST' })
+      expect(res.status).toBe(401)
+    })
+
+    it('returns 403 for non-admin users', async () => {
+      const res = await fetch(PUBLISH_URL, {
+        method: 'POST',
+        headers: { Cookie: noahCookies },
+      })
+      expect(res.status).toBe(403)
+    })
+
+    it('returns 403 for staff users', async () => {
+      const res = await fetch(PUBLISH_URL, {
+        method: 'POST',
+        headers: { Cookie: staffCookies },
+      })
+      expect(res.status).toBe(403)
+    })
+
+    it('publishes all scheduled sessions and returns count', async () => {
+      // Verify there are scheduled sessions before the call
+      const beforeRes = await fetch(`${BASE}?status=scheduled`, {
+        headers: { Cookie: adminCookies },
+      })
+      const before = await beforeRes.json() as { status: string }[]
+      const scheduledBefore = before.filter(s => s.status === 'scheduled').length
+      expect(scheduledBefore).toBeGreaterThan(0)
+
+      const res = await fetch(PUBLISH_URL, {
+        method: 'POST',
+        headers: { Cookie: adminCookies },
+      })
+      expect(res.status).toBe(200)
+      const body = await res.json() as { published: number }
+      expect(body.published).toBe(scheduledBefore)
+
+      // Verify no scheduled sessions remain
+      const afterRes = await fetch(`${BASE}?status=scheduled`, {
+        headers: { Cookie: adminCookies },
+      })
+      const after = await afterRes.json() as { status: string }[]
+      expect(after.filter(s => s.status === 'scheduled').length).toBe(0)
+
+      // Restore scheduled sessions for subsequent tests
+      await migrateAndSeed()
+    })
+
+    it('returns 0 when there are no scheduled sessions', async () => {
+      // First call publishes all scheduled sessions
+      await fetch(PUBLISH_URL, {
+        method: 'POST',
+        headers: { Cookie: adminCookies },
+      })
+
+      // Second call should find nothing to publish
+      const res = await fetch(PUBLISH_URL, {
+        method: 'POST',
+        headers: { Cookie: adminCookies },
+      })
+      expect(res.status).toBe(200)
+      const body = await res.json() as { published: number }
+      expect(body.published).toBe(0)
+
+      // Restore for other tests
+      await migrateAndSeed()
+    })
+  })
 })


### PR DESCRIPTION
## Why

After scheduling sessions across rounds, admins need a way to flip all scheduled sessions back to "published" in one action -- for example before opening a new scheduling round or correcting an over-eager batch assignment. Doing this one-by-one via the edit dialog is tedious and error-prone.

## What changed

**API -- `POST /api/events/[eventId]/sessions/publish-scheduled`**

A new admin-only endpoint that bulk-updates every session with `status = 'scheduled'` for the given event to `status = 'published'`. Returns `{ published: N }` with the count of affected rows. Non-admins (including staff) receive 403.

**Admin sessions page**

- A green **"Publish Scheduled (N)"** button sits next to "Create Session". The count shows how many scheduled sessions exist; the button is disabled when N = 0.
- Clicking it opens a confirmation dialog that names the exact count before committing.
- After the call succeeds a dismissible success banner confirms how many sessions were published and the table refreshes automatically.

**Tests**

Four new integration test cases in `test/api/sessions.test.ts`:
- 401 for unauthenticated requests
- 403 for non-admin (participant) and staff users
- Happy path: verifies scheduled sessions exist before, checks the returned count matches, then confirms zero scheduled sessions remain after
- Idempotent second call: returns `{ published: 0 }` when nothing is left to publish

Both test cases that mutate data restore the DB via `migrateAndSeed()` so they don't affect other tests.